### PR TITLE
DNS workaround for DCOS w/ Alpine Linux.

### DIFF
--- a/run
+++ b/run
@@ -10,6 +10,10 @@ else
   rm /tmp/server-*.pem
 fi
 
+# This is a hack due to musl libc's DNS handling
+cat /etc/resolv.conf | head -n 3 > dns
+cat dns > /etc/resolv.conf
+
 /sbin/runsv "$SERVICE" &
 RUNSV=$!
 


### PR DESCRIPTION
Alpine Linux uses musl libc which does not respect the order of DNS
servers in /etc/resolv.conf. Since we include a fallback DNS server as
the last entry (which is not Mesos-DNS), DNS lookups will randomly fail.

cc @discordianfish 