### PR TITLE
Use debian as base image and bash for scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM alpine
+FROM debian
 
 ENTRYPOINT [ "/marathon-lb/run" ]
 CMD        [ "sse", "-m", "http://leader.mesos:8080" ]
 EXPOSE     80 443 8080 
 
-RUN apk add --update python py-pip haproxy openssl \
-    && apk add --update --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
-    runit \
-    && pip install requests sseclient
+RUN apt-get update && apt-get install -y python python-pip haproxy openssl runit \
+    && pip install requests sseclient \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY  . /marathon-lb
 WORKDIR /marathon-lb

--- a/run
+++ b/run
@@ -1,6 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+
 SERVICE="/marathon-lb/service/haproxy"
-if [ -n "$HAPROXY_SSL_CERT" ]; then
+if [ -n "${HAPROXY_SSL_CERT-}" ]; then
   echo "$HAPROXY_SSL_CERT" > /etc/ssl/mesosphere.com.pem
 else
   openssl genrsa -out /tmp/server-key.pem 2048
@@ -10,7 +12,7 @@ else
   rm /tmp/server-*.pem
 fi
 
-/sbin/runsv "$SERVICE" &
+/usr/bin/runsv "$SERVICE" &
 RUNSV=$!
 
 trap "kill $RUNSV; wait $RUNSV; exit 0" TERM INT

--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 exec 2>&1
 PIDFILE="/tmp/haproxy.pid"
 exec 200<$0


### PR DESCRIPTION
Alpine is much smaller but it suffers from severe DNS issues. It lacks
support for search domains and tries to resolve a dns name via all
configure nameservers and returns the first answer. Since we keep a
non-mesos dns server for backup, sometimes this one is faster and we get
NXDOMAIN for internal names.

- https://github.com/gliderlabs/docker-alpine/issues/8
- https://github.com/gliderlabs/docker-alpine/issues/11