### PR TITLE
Enable HAProxy redispatch by default.

### DIFF
--- a/marathon-update-haproxy.py
+++ b/marathon-update-haproxy.py
@@ -243,6 +243,7 @@ class ConfigTemplater(object):
       timeout connect   5s
       timeout client    50s
       timeout server    50s
+      option            redispatch
     listen stats
       bind 0.0.0.0:9090
       balance


### PR DESCRIPTION
We should enable `redispatch` by default. See the HAProxy docs for details on what this does: https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-option%20redispatch

cc @discordianfish 