### PR TITLE
Handle request errors gracefully, rather than aborting entirely.

### DIFF
--- a/marathon-update-haproxy.py
+++ b/marathon-update-haproxy.py
@@ -1044,7 +1044,10 @@ class MarathonEventProcessor(object):
         if event['eventType'] == 'status_update_event' or event['eventType'] == 'health_status_changed_event':
             # TODO (cmaloney): Handle events more intelligently so we don't
             # unnecessarily hammer the Marathon API.
-            self.reset_from_tasks()
+            try:
+                self.reset_from_tasks()
+            except requests.exceptions.ConnectionError as e:
+                logger.error("Connection error({0}): {1}".format(e.errno, e.strerror))
 
 
 def get_arg_parser():


### PR DESCRIPTION
I ran a benchmark and marathon-lb crashed:

```
servicerouter: reading running config from /marathon-lb/haproxy.cfg
servicerouter: updating tasks finished, took 0.0192270278931 seconds
servicerouter: received event of type status_update_event
servicerouter: fetching apps
Traceback (most recent call last):
  File "/marathon-lb/marathon-update-haproxy.py", line 1210, in <module>
    process_sse_events(marathon, args.haproxy_config, args.group)
  File "/marathon-lb/marathon-update-haproxy.py", line 1153, in process_sse_events
    processor.handle_event(data)
  File "/marathon-lb/marathon-update-haproxy.py", line 1047, in handle_event
    self.reset_from_tasks()
  File "/marathon-lb/marathon-update-haproxy.py", line 1034, in reset_from_tasks
    self.__apps = get_apps(self.__marathon)
  File "/marathon-lb/marathon-update-haproxy.py", line 943, in get_apps
    apps = marathon.list()
  File "/marathon-lb/marathon-update-haproxy.py", line 609, in list
    params={'embed': 'apps.tasks'})["apps"]
  File "/marathon-lb/marathon-update-haproxy.py", line 596, in api_req
    return self.api_req_raw(method, path, **kwargs).json()
  File "/marathon-lb/marathon-update-haproxy.py", line 582, in api_req_raw
    **kwargs
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 49, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 407, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', gaierror(-2, 'Name or service not known'))
```

Let's not crash!

cc @discordianfish 