### PR TITLE
Multiple SSL certificate config for frontend marathon_https_in

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ this service in your public slaves.
 Synopsis: `docker run mesosphere/marathon-lb event|poll ...`
 
 You can pass in your own certificates for the SSL frontend by setting
-the HAPROXY_SSL_CERT environment variable.
+the HAPROXY_SSL_CERTS environment variable. You can split the certificate paths
+with comma (,)
+
+Example: /etc/ssl/mesosphere.com.pem,/etc/ssl/mesosphere2.com.pem
 
 #### sse mode
 In SSE mode, the script connects to the marathon events endpoint to get


### PR DESCRIPTION
We can now provide multiple ssl certificates for the **frontend marathon_https_in** group.

    export HAPROXY_SSL_CERTS=/etc/ssl/mesosphere.com.pem,/etc/ssl/mesosphere2.com.pem  

and then running the script will create a line like following:

    bind *:443 ssl crt /etc/ssl/mesosphere.com.pem crt /etc/ssl/mesosphere2.com.pem

We can provide single certificate:

    export HAPROXY_SSL_CERTS=/etc/ssl/mesosphere.com.pem

resulting in:

    bind *:443 ssl crt /etc/ssl/mesosphere.com.pem

Or without any env variable, it is set by default:

    bind *:443 ssl crt /etc/ssl/mesosphere.com.pem