### PR TITLE
Close file descriptors when forking subprocess to reload haproxy

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -775,7 +775,7 @@ def reloadConfig():
     if reloadCommand:
         logger.info("reloading using %s", " ".join(reloadCommand))
         try:
-            subprocess.check_call(reloadCommand)
+            subprocess.check_call(reloadCommand, close_fds=True)
         except OSError as ex:
             logger.error("unable to reload config using command %s",
                          " ".join(reloadCommand))


### PR DESCRIPTION
References #28 