### PR TITLE
Fix to stop interpolation of escaped asterisk

### DIFF
--- a/run
+++ b/run
@@ -70,7 +70,7 @@ while true; do
     --syslog-socket /dev/null \
     --haproxy-config /marathon-lb/haproxy.cfg \
     -c "sv reload $SERVICE" \
-    $ARGS $@ &
+    $ARGS "$@" &
   wait $! || exit $? # Needed for the traps to work
   if [ "$MODE" != "poll" ]; then
     exit 0


### PR DESCRIPTION
I noticed that I cannot pass an asterisk to `--group`(using docker run or marathon-lb/run) and get the marathon-lb.py script to find all marathon apps.

This is a possible fix. Other options are `set -f` in marathon-lb/run or another `--all-groups` option in marathon-lb.py.