### PR TITLE
Refactor vhost ACL generation

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -606,25 +606,9 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
         # TODO(lloesche): Check if the hostname is already defined by another
         # service
         if bind_http_https and app.hostname:
-            logger.debug(
-                "adding virtual host for app with hostname %s", app.hostname)
-            cleanedUpHostname = re.sub(r'[^a-zA-Z0-9\-]', '_', app.hostname)
-
-            http_frontend_acl = templater.haproxy_http_frontend_acl(app)
-            http_frontends += http_frontend_acl.format(
-                cleanedUpHostname=cleanedUpHostname,
-                hostname=app.hostname,
-                appId=app.appId,
-                backend=backend
-            )
-
-            https_frontend_acl = templater.haproxy_https_frontend_acl(app)
-            https_frontends += https_frontend_acl.format(
-                cleanedUpHostname=cleanedUpHostname,
-                hostname=app.hostname,
-                appId=app.appId,
-                backend=backend
-            )
+            p_fe, s_fe = generateHttpVhostAcl(templater, app, backend)
+            http_frontends += p_fe
+            https_frontends += s_fe
 
         # if app mode is http, we add the app to the second http frontend
         # selecting apps by http header X-Marathon-App-Id
@@ -784,6 +768,36 @@ def reloadConfig():
             logger.error("unable to reload config using command %s",
                          " ".join(reloadCommand))
             logger.error("reload returned non-zero: %s", ex)
+
+
+def generateHttpVhostAcl(templater, app, backend):
+    # If the hostname contains the delimiter ';', then the marathon app is
+    # requesting multiple hostname matches for the same backend, and we need
+    # to use alternate templates from the default one-acl/one-use_backend.
+    staging_http_frontends = ""
+    staging_https_frontends = ""
+
+    logger.debug(
+        "adding virtual host for app with hostname %s", app.hostname)
+    acl_name = re.sub(r'[^a-zA-Z0-9\-]', '_', app.hostname)
+
+    http_frontend_acl = templater.haproxy_http_frontend_acl(app)
+    staging_http_frontends += http_frontend_acl.format(
+        cleanedUpHostname=acl_name,
+        hostname=app.hostname,
+        appId=app.appId,
+        backend=backend
+    )
+
+    https_frontend_acl = templater.haproxy_https_frontend_acl(app)
+    staging_https_frontends += https_frontend_acl.format(
+        cleanedUpHostname=acl_name,
+        hostname=app.hostname,
+        appId=app.appId,
+        backend=backend
+    )
+
+    return (staging_http_frontends, staging_https_frontends)
 
 
 def writeConfigAndValidate(config, config_file):

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -280,3 +280,81 @@ backend nginx_10000
   mode tcp
 '''
         self.assertMultiLineEqual(config, expected)
+
+    def test_config_simple_app_vhost(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 0,
+            "gracePeriodSeconds": 10,
+            "intervalSeconds": 2,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "ignoreHttp1xx": False
+        }
+        app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app.hostname = "test.example.com"
+        app.groups = ['external']
+        apps = [app]
+
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = '''global
+  daemon
+  log /dev/log local0
+  log /dev/log local1 notice
+  maxconn 4096
+  tune.ssl.default-dh-param 2048
+defaults
+  log               global
+  retries           3
+  maxconn           2000
+  timeout connect   5s
+  timeout client    50s
+  timeout server    50s
+  option            redispatch
+listen stats
+  bind 0.0.0.0:9090
+  balance
+  mode http
+  stats enable
+  monitor-uri /_haproxy_health_check
+
+frontend marathon_http_in
+  bind *:80
+  mode http
+  acl host_test_example_com hdr(host) -i test.example.com
+  use_backend nginx_10000 if host_test_example_com
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+  acl app__nginx hdr(x-marathon-app-id) -i /nginx
+  use_backend nginx_10000 if app__nginx
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+  use_backend nginx_10000 if { ssl_fc_sni test.example.com }
+
+frontend nginx_10000
+  bind *:10000
+  mode http
+  use_backend nginx_10000
+
+backend nginx_10000
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+'''
+        self.assertMultiLineEqual(config, expected)


### PR DESCRIPTION
This is dependent on #48 

Git message:

This patch adds no new functionality, but refactors some code out of the config() function:

* Create a new function, generateHttpVhostAcl() which returns a string to add to config()'s http{,s}_frontends strings
* The code in config() is replaced by appending the return strings of generateHttpVhostAcl() to http{,s}_frontends.

This particular change likely doesn't make much sense on its own, but it required for the next pull request I'm about to submit.

For testing, I manually verified that the config generated was identical, and the tests all succeed, particularly the test introduced in #48, which tests this exact functionality.