### PR TITLE
Add support for multiple vhosts for a single service port

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,16 @@ own templates to the Docker image, or provide them at startup.
     The ACL that glues a backend to the corresponding virtual host
     of the HAPROXY_HTTP_FRONTEND_HEAD.
 
+  HAPROXY_HTTP_FRONTEND_ACL_ONLY
+    Define the ACL matching a particular hostname, but unlike
+    HAPROXY_HTTP_FRONTEND_ACL, only do the ACL portion. Does not glue
+    the ACL to the backend. This is useful only in the case of multiple
+    vhosts routing to the same backend
+
+  HAPROXY_HTTP_FRONTEND_ROUTING_ONLY
+    This is the counterpart to HAPROXY_HTTP_FRONTEND_ACL_ONLY which
+    glues the acl name to the appropriate backend.
+
   HAPROXY_HTTP_FRONTEND_APPID_ACL
     The ACL that glues a backend to the corresponding app
     of the HAPROXY_HTTP_FRONTEND_APPID_HEAD.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ for reference) as defined in their Marathon definition. Furthermore, apps are
 only exposed on LBs which have the same LB tag (or group) as defined in the Marathon
 app's labels (using `HAPROXY_GROUP`). HAProxy parameters can be tuned by specify labels in your app.
 
-To create a virtual host the `HAPROXY_0_VHOST` label needs to be set on the
+To create a virtual host or hosts the `HAPROXY_0_VHOST` label needs to be set on the
 given application. Applications with a vhost set will be exposed on ports 80
-and 443, in addition to their service port.
+and 443, in addition to their service port. Multiple virtual hosts may be specified
+in HAPROXY_0_VHOST using a comma as a delimiter between hostnames.
 
 All applications are also exposed on port 9091, using the `X-Marathon-App-Id`
 HTTP header. See the documentation for `HAPROXY_HTTP_FRONTEND_APPID_HEAD` in
@@ -162,8 +163,9 @@ The full list of labels which can be specified are:
     The target number of app instances to seek during deployment. You generally do not need to modify this unless you implement your own deployment orchestrator.
 
   HAPROXY_{n}_VHOST
-    The Marathon HTTP Virtual Host proxy hostname to gather.
+    The Marathon HTTP Virtual Host proxy hostname(s) to gather.
     Ex: HAPROXY_0_VHOST = 'marathon.mesosphere.com'
+    Ex: HAPROXY_0_VHOST = 'marathon.mesosphere.com,marathon'
 
   HAPROXY_{n}_STICKY
     Enable sticky request routing for the service.

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -860,7 +860,7 @@ def generateHttpVhostAcl(templater, app, backend):
                 backend=backend
             )
 
-        # We've added the http acl lines, now route them all to the same backend
+        # We've added the http acl lines, now route them to the same backend
         http_frontend_route = templater.haproxy_http_frontend_routing_only(app)
         staging_http_frontends += http_frontend_route.format(
             cleanedUpHostname=acl_name,

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -831,16 +831,16 @@ def reloadConfig():
 
 
 def generateHttpVhostAcl(templater, app, backend):
-    # If the hostname contains the delimiter ';', then the marathon app is
+    # If the hostname contains the delimiter ',', then the marathon app is
     # requesting multiple hostname matches for the same backend, and we need
     # to use alternate templates from the default one-acl/one-use_backend.
     staging_http_frontends = ""
     staging_https_frontends = ""
 
-    if ";" in app.hostname:
+    if "," in app.hostname:
         logger.debug(
             "vhost label specifies multiple hosts: %s", app.hostname)
-        vhosts = app.hostname.split(';')
+        vhosts = app.hostname.split(',')
         acl_name = re.sub(r'[^a-zA-Z0-9\-]', '_', vhosts[0])
 
         for vhost_hostname in vhosts:

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -406,7 +406,7 @@ backend nginx_10000
             "ignoreHttp1xx": False
         }
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
-        app.hostname = "test.example.com;test"
+        app.hostname = "test.example.com,test"
         app.groups = ['external']
         apps = [app]
 

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -387,3 +387,83 @@ backend nginx_10000
   server 10_0_6_25_31184 10.0.6.25:31184 check inter 3s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
+
+    def test_config_simple_app_multiple_vhost(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 0,
+            "gracePeriodSeconds": 10,
+            "intervalSeconds": 2,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "ignoreHttp1xx": False
+        }
+        app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app.hostname = "test.example.com;test"
+        app.groups = ['external']
+        apps = [app]
+
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = '''global
+  daemon
+  log /dev/log local0
+  log /dev/log local1 notice
+  maxconn 4096
+  tune.ssl.default-dh-param 2048
+defaults
+  log               global
+  retries           3
+  maxconn           2000
+  timeout connect   5s
+  timeout client    50s
+  timeout server    50s
+  option            redispatch
+listen stats
+  bind 0.0.0.0:9090
+  balance
+  mode http
+  stats enable
+  monitor-uri /_haproxy_health_check
+
+frontend marathon_http_in
+  bind *:80
+  mode http
+  acl host_test_example_com hdr(host) -i test.example.com
+  acl host_test_example_com hdr(host) -i test
+  use_backend nginx_10000 if host_test_example_com
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+  acl app__nginx hdr(x-marathon-app-id) -i /nginx
+  use_backend nginx_10000 if app__nginx
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+  use_backend nginx_10000 if { ssl_fc_sni test.example.com }
+  use_backend nginx_10000 if { ssl_fc_sni test }
+
+frontend nginx_10000
+  bind *:10000
+  mode http
+  use_backend nginx_10000
+
+backend nginx_10000
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+'''
+        self.assertMultiLineEqual(config, expected)

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -412,27 +412,7 @@ backend nginx_10000
 
         config = marathon_lb.config(apps, groups, bind_http_https,
                                     ssl_certs, templater)
-        expected = '''global
-  daemon
-  log /dev/log local0
-  log /dev/log local1 notice
-  maxconn 4096
-  tune.ssl.default-dh-param 2048
-defaults
-  log               global
-  retries           3
-  maxconn           2000
-  timeout connect   5s
-  timeout client    50s
-  timeout server    50s
-  option            redispatch
-listen stats
-  bind 0.0.0.0:9090
-  balance
-  mode http
-  stats enable
-  monitor-uri /_haproxy_health_check
-
+        expected = self.base_config + '''
 frontend marathon_http_in
   bind *:80
   mode http


### PR DESCRIPTION
This is dependent on #49 

Git commit message:

Allow a Marathon user to request multiple vhosts for a single service port by putting semi-colon-delimited hostnames in the application's HAPROXY_{0}_VHOST Marathon label, requiring the following changes:

- In the case where a vhost label contains a delimiter, use a combination of two newly-added templates HAPROXY_HTTP_FRONTEND_ACL_ONLY and HAPROXY_HTTP_FRONTEND_ROUTING_ONLY instead of the current HAPROXY_HTTP_FRONTEND_ACL
- In the traditional case of a single hostname in the application label, HAPROXY_HTTP_FRONTEND_ACL is still used
- Add a test case for multiple vhosts

All the previous tests succeed, and the newly added test tests the particular functionality introduced in the PR.