### PR TITLE
Fix unbound variable

### DIFF
--- a/run
+++ b/run
@@ -67,7 +67,7 @@ case "$MODE" in
     ;;
 esac
 
-if [ -n "${HAPROXY_SYSCTL_PARAMS}" ]; then
+if [ -n "${HAPROXY_SYSCTL_PARAMS-}" ]; then
   echo "setting sysctl params to: ${HAPROXY_SYSCTL_PARAMS}"
   sysctl $HAPROXY_SYSCTL_PARAMS
 fi


### PR DESCRIPTION
With set -u, referencing $HAPROXY_SYSCTL_PARAMS will cause errors like "/marathon-lb/run: line 70: HAPROXY_SYSCTL_PARAMS: unbound variable". This effectively break existing setups.