### PR TITLE
In SSE mode, on failure cycle through hosts instead of hard coded first one

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -50,6 +50,7 @@ from textwrap import dedent
 from wsgiref.simple_server import make_server
 from sseclient import SSEClient
 from six.moves.urllib import parse
+from itertools import cycle
 from common import *
 
 import argparse
@@ -464,6 +465,7 @@ class Marathon(object):
         self.__hosts = hosts
         self.__health_check = health_check
         self.__auth = auth
+        self.__cycle_hosts = cycle(self.__hosts)
 
     def api_req_raw(self, method, path, auth, body=None, **kwargs):
         for host in self.__hosts:
@@ -528,10 +530,14 @@ class Marathon(object):
                 params={'callbackUrl': callbackUrl})
 
     def get_event_stream(self):
-        url = self.__hosts[0]+"/v2/events"
+        url = self.host+"/v2/events"
         logger.info(
             "SSE Active, trying fetch events from from {0}".format(url))
         return SSEClient(url, auth=self.__auth)
+
+    @property
+    def host(self):
+        return next(self.__cycle_hosts)
 
 
 def has_group(groups, app_groups):


### PR DESCRIPTION
marathon-lb has always supported multiple --marathon/-m arguments. However the current code only uses those when polling. When using SSE the first host is hard coded.

This is okayish for DCOS where we usually only use one RRDNS host `-m http://master.mesos:8080` but bad for Mesos/Marathon deployments without mesos-dns. This PR fixes that by cycling through the hosts, making get_event_stream() return the next in the list whenever it's called.
