### PR TITLE
Set default secure ssl ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ The full list of labels which can be specified are:
     Enable the given SSL certificate for TLS/SSL traffic.
     Ex: HAPROXY_0_SSL_CERT = '/etc/ssl/certs/marathon.mesosphere.com'
 
+  HAPROXY_{n}_BIND_OPTIONS
+    Set additional bind options
+    Ex: HAPROXY_0_BIND_OPTIONS = 'ciphers AES128+EECDH:AES128+EDH force-tlsv12 no-sslv3'
+
   HAPROXY_{n}_BIND_ADDR
     Bind to the specific address for the service.
     Ex: HAPROXY_0_BIND_ADDR = '10.0.0.42'

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -79,6 +79,8 @@ class ConfigTemplater(object):
       log /dev/log local1 notice
       maxconn 10000
       tune.ssl.default-dh-param 2048
+      ssl-default-bind-options no-sslv3 no-tls-tickets force-tlsv12
+      ssl-default-bind-ciphers AES128+EECDH:AES128+EDH
       server-state-file global
       server-state-base /var/state/haproxy/
       lua-load /marathon-lb/getpids.lua
@@ -123,7 +125,7 @@ class ConfigTemplater(object):
 
     HAPROXY_FRONTEND_HEAD = dedent('''
     frontend {backend}
-      bind {bindAddr}:{servicePort}{sslCertOptions}
+      bind {bindAddr}:{servicePort}{sslCert}{bindOptions}
       mode {mode}
     ''')
 
@@ -367,6 +369,10 @@ def set_sslCert(x, k, v):
     x.sslCert = v
 
 
+def set_bindOptions(x, k, v):
+    x.bindOptions = v
+
+
 def set_bindAddr(x, k, v):
     x.bindAddr = v
 
@@ -392,6 +398,7 @@ label_keys = {
     'HAPROXY_{0}_STICKY': set_sticky,
     'HAPROXY_{0}_REDIRECT_TO_HTTPS': set_redirect_http_to_https,
     'HAPROXY_{0}_SSL_CERT': set_sslCert,
+    'HAPROXY_{0}_BIND_OPTIONS': set_bindOptions,
     'HAPROXY_{0}_BIND_ADDR': set_bindAddr,
     'HAPROXY_{0}_PORT': set_port,
     'HAPROXY_{0}_MODE': set_mode,
@@ -439,6 +446,7 @@ class MarathonService(object):
         self.sticky = False
         self.redirectHttpToHttps = False
         self.sslCert = None
+        self.bindOptions = None
         self.bindAddr = '*'
         self.groups = frozenset()
         self.mode = 'tcp'
@@ -633,7 +641,8 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
             backend=backend,
             servicePort=app.servicePort,
             mode=app.mode,
-            sslCertOptions=' ssl crt ' + app.sslCert if app.sslCert else ''
+            sslCert=' ssl crt ' + app.sslCert if app.sslCert else '',
+            bindOptions=' ' + app.bindOptions if app.bindOptions else ''
         )
 
         if app.redirectHttpToHttps:

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -11,6 +11,8 @@ class TestMarathonUpdateHaproxy(unittest.TestCase):
   log /dev/log local1 notice
   maxconn 10000
   tune.ssl.default-dh-param 2048
+  ssl-default-bind-options no-sslv3 no-tls-tickets force-tlsv12
+  ssl-default-bind-ciphers AES128+EECDH:AES128+EDH
   server-state-file global
   server-state-base /var/state/haproxy/
   lua-load /marathon-lb/getpids.lua


### PR DESCRIPTION
This PR sets secure SSL ciphers by default, turns off SSLv3 and forces TLS v1.2 which has been default in all popular browsers since Feb 2014.

It also adds the ability to set cert options in addition to defining a certificate.
I also renamed sslCertOptions in the HAPROXY_FRONTEND_HEAD template to sslCert since the corresponding label was always called `HAPROXY_0_SSL_CERT`.

I added HAPROXY_0_BIND_OPTIONS for specifying additional bind options.
This allows users to explicitly specify insecure ciphers if they so desire for e.g. backwards compatibility.