### PR TITLE
remove error output suppression for pep8 checks

### DIFF
--- a/tests/test_code_style.py
+++ b/tests/test_code_style.py
@@ -14,7 +14,7 @@ class TestCodeFormat(unittest.TestCase):
 
     def test_pep8_conformance(self):
         """Test that we conform to PEP8."""
-        pep8style = pep8.StyleGuide(quiet=True)
+        pep8style = pep8.StyleGuide()
         result = pep8style.check_files(self.get_py_files())
         self.assertEqual(result.total_errors, 0,
                          "Found code style errors (and warnings).")


### PR DESCRIPTION
I want to know in which file, line and for what reason the pep8 check failed. With this change I'll get output like
```
-------------------- >> begin captured stdout << ---------------------
/home/lukas/repo/mesosphere/marathon-lb/marathon_lb.py:649:13: E131 continuation line unaligned for hanging indent

--------------------- >> end captured stdout << ----------------------
```
instead of the assertion error only.