### PR TITLE
Registering a HTTP callback has failed in event mode

### DIFF
--- a/run
+++ b/run
@@ -65,7 +65,7 @@ case "$MODE" in
       exit 1
     fi
     echo "Using $URL as event callback-url"
-    ARGS="-l :8080 -u '$URL'"
+    ARGS="-u $URL"
     ;;
   *)
     echo "Unknown mode $MODE. Synopsis: $0 poll|sse|event [marathon_lb.py args]" >&2


### PR DESCRIPTION
Single quotation mark is added when running Docker container using event mode. 

[Docker run command]
```
docker run -e "PORTS=8080" --privileged --net=host mesosphere/marathon-lb:v1.1.1 event http://172.26.111.14:8080 -m http://192.168.99.100:8080 -l http://172.26.111.14:8080 --group external
```

[Marathon log]
```
spray.http.IllegalUriException: Illegal URI reference, unexpected character ':' at position 5:
'http://172.26.111.14:8080'
     ^
marathon_1 |
 at spray.http.Uri$.fail(Uri.scala:775)
 at spray.http.parser.UriParser.complete(UriParser.scala:429)
 at spray.http.parser.UriParser.parseReference(UriParser.scala:60)
 at spray.http.Uri$.apply(Uri.scala:231)
 at spray.http.Uri$.apply(Uri.scala:203)
 at spray.httpx.RequestBuilding$RequestBuilder.apply(RequestBuilding.scala:36)
 at spray.httpx.RequestBuilding$RequestBuilder.apply(RequestBuilding.scala:35)
 at mesosphere.marathon.event.http.HttpEventActor.post(HttpEventActor.scala:94)
 at mesosphere.marathon.event.http.HttpEventActor$$anonfun$broadcast$1$$anonfun$apply$1.apply(HttpEventActor.scala:86)
 at mesosphere.marathon.event.http.HttpEventActor$$anonfun$broadcast$1$$anonfun$apply$1.apply(HttpEventActor.scala:86)
```