### PR TITLE
added support for haproxy group per service port.

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -455,8 +455,8 @@ def set_balance(x, k, v):
 def set_label(x, k, v):
     x.labels[k] = v
 
-def set_group(x,k,v):
-    x.haproxy_groups=v.split(',')
+def set_group(x, k, v):
+    x.haproxy_groups = v.split(',')
 
 
 label_keys = {
@@ -691,13 +691,15 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
 
     for app in sorted(apps, key=attrgetter('appId', 'servicePort')):
         # App only applies if we have it's group
-        ## Check if there is a haproxy group associated with service group, if not fallback to original HAPROXY group. This is added for backward compatability with HAPROXY_GROUP 
-	if app.haproxy_groups:
+        # Check if there is a haproxy group associated with service group, 
+	# if not fallback to original HAPROXY group.
+	# This is added for backward compatability with HAPROXY_GROUP 
+        if app.haproxy_groups:
             if not has_group(groups, app.haproxy_groups):
                 continue
-	else:
+        else:
 	    if not has_group(groups, app.groups):
-		continue
+                continue
 
         logger.debug("configuring app %s", app.appId)
         backend = app.appId[1:].replace('/', '_') + '_' + str(app.servicePort)

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -455,9 +455,13 @@ def set_balance(x, k, v):
 def set_label(x, k, v):
     x.labels[k] = v
 
+def set_group(x,k,v):
+    x.haproxy_groups=v.split(',')
+
 
 label_keys = {
     'HAPROXY_{0}_VHOST': set_hostname,
+    'HAPROXY_{0}_GROUP': set_group,
     'HAPROXY_{0}_PATH': set_path,
     'HAPROXY_{0}_STICKY': set_sticky,
     'HAPROXY_{0}_REDIRECT_TO_HTTPS': set_redirect_http_to_https,
@@ -507,6 +511,7 @@ class MarathonService(object):
         self.servicePort = servicePort
         self.backends = set()
         self.hostname = None
+        self.haproxy_groups = frozenset()
         self.path = None
         self.sticky = False
         self.redirectHttpToHttps = False
@@ -686,7 +691,7 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
 
     for app in sorted(apps, key=attrgetter('appId', 'servicePort')):
         # App only applies if we have it's group
-        if not has_group(groups, app.groups):
+        if not has_group(groups, app.haproxy_groups):
             continue
 
         logger.debug("configuring app %s", app.appId)

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -691,8 +691,13 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
 
     for app in sorted(apps, key=attrgetter('appId', 'servicePort')):
         # App only applies if we have it's group
-        if not has_group(groups, app.haproxy_groups):
-            continue
+        ## Check if there is a haproxy group associated with service group, if not fallback to original HAPROXY group. This is added for backward compatability with HAPROXY_GROUP 
+	if app.haproxy_groups:
+            if not has_group(groups, app.haproxy_groups):
+                continue
+	else:
+	    if not has_group(groups, app.groups):
+		continue
 
         logger.debug("configuring app %s", app.appId)
         backend = app.appId[1:].replace('/', '_') + '_' + str(app.servicePort)


### PR DESCRIPTION
Added support for haproxy group per service port. Currently both service port had to be part of same hagroup group. Now similar to Vhost, we can have different haproxy group per service port. This allows us to have external and internal services running on same box on different service ports, as they can be part of different haproxy group. This supports,

HAPROXY_0_GROUP
HAPROXY_1_GROUP 
and maps them to corresponding service ports.

It is backward compatible as well, so it supports HAPROXY_GROUP.

If both HAPROXY_0_GROUP and HAPROXY_GROUP are specified, the more specific definition takes preference and the service group will be added to HAPROXY_0_GROUP and not HAPROXY_GROUP.

If there are 2 services HAPROXY_0_PORT and HAPROXY_1_PORT and if HAPROXY_0_GROUP and HAPROXY_GROUP labels are defined. HAPROXY_0_PORT service is added to HAPROXY_0_GROUP and HAPROXY_1_PORT is added to HAPROXY_GROUP since HAPROXY_1_GROUP is not specified for it.