### PR TITLE
added support for haproxy group per service port

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The full list of labels which can be specified are:
 ```
   HAPROXY_GROUP
     The group of marathon-lb instances that point to the service.
+    This is a global group for all services running on different vhosts in a application
+    This can be overrided for each service port. If it is not overriden this will be default group.
     Load balancers with the group '*' will collect all groups.
 
   HAPROXY_DEPLOYMENT_GROUP
@@ -200,6 +202,28 @@ The full list of labels which can be specified are:
     Bind to the specific port for the service.
     This overrides the servicePort which has to be unique.
     Ex: HAPROXY_0_PORT = 80
+
+  HAPROXY_{n}_GROUP
+    Haproxy group per service. This helps us have different HA Proxy groups per service port.
+    This overrides HAPROXY_GROUP for the particular service.
+    If you have both external and internal services running on same set of instances on
+    different ports, you can use this feature to add them to different haproxy configs.
+    Ex: HAPROXY_0_GROUP = 'external'
+        HAPROXY_1_GROUP = 'internal'
+
+    Now if you run marathon_lb with --group external, it just adds the service on HAPROXY_0_PORT
+    (or first service port incase HAPROXY_0_HOST is not configured) to haproxy config and similarly
+    if you run it with --group internal, it adds service on HAPROXY_1_PORT to haproxy config.
+    If the configuration is a combination of HAPROXY_GROUP and HAPROXY_{n}_GROUP,
+    the more specific definition takes precedence.
+    Ex: HAPROXY_0_GROUP = 'external'
+        HAPROXY_GROUP   = 'internal'
+
+    Considering the above example where the configuration is hybrid, Service running on
+    HAPROXY_0_PORT is associated with just 'external' haproxy group and not 'internal' group.
+    And since there is no Haproxy group mentioned for second service (HAPROXY_1_GROUP not defined)
+    it falls back to default HAPROXY_GROUP and gets associated with 'internal' group.
+
 
   HAPROXY_{n}_MODE
     Set the connection mode to either TCP or HTTP. The default is TCP.
@@ -448,4 +472,4 @@ An example minimal configuration for a [test instance of nginx is included here]
 ./bluegreen_deploy.py -j 1-nginx.json -m http://master.mesos:8080 -f -l http://marathon-lb.marathon.mesos:9090
 ```
 
-Zero downtime deployments are accomplished through the use of a Lua module, which reports the number of HAProxy processes which are currently running by hitting the stats endpoint at the `/_haproxy_getpids`. After a restart, there will be multiple HAProxy PIDs until all remaining connections have gracefully terminated. By waiting for all connections to complete, you may safely and deterministically drain tasks.
+Zero downtime deployments are accomplished through the use of a Lua module, which reports the number of HAProxy processes which are currently running by hitting the stats endpoint at the `/_haproxy_getpids`. After a restart, there will be multiple HAProxy PIDs until all remaining connections have gracefully terminated. By waiting for all connections to complete, you may safely and deterministically drain tasks. A caveat of this, however, is that if you have any long-lived connections on the same LB, HAProxy will continue to run and serve those connections until they complete, thereby breaking this technique.

--- a/run
+++ b/run
@@ -65,7 +65,7 @@ case "$MODE" in
       exit 1
     fi
     echo "Using $URL as event callback-url"
-    ARGS="-l :8080 -u '$URL'"
+    ARGS="-u $URL"
     ;;
   *)
     echo "Unknown mode $MODE. Synopsis: $0 poll|sse|event [marathon_lb.py args]" >&2

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -220,7 +220,7 @@ frontend nginx_10000
 backend nginx_10000
   balance roundrobin
   mode tcp
-  server 1_1_1_1_1024 1.1.1.1:1024
+  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -636,5 +636,198 @@ backend nginx_10000
   option  httpchk GET /
   timeout check 10s
   server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11 port 1024
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_simple_app_tcp_healthcheck(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {
+            "protocol": "TCP",
+            "portIndex": 0,
+            "gracePeriodSeconds": 10,
+            "intervalSeconds": 2,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "ignoreHttp1xx": False
+        }
+        app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app.groups = ['external']
+        app.add_backend("1.1.1.1", 1024, False)
+        app.hostname = "test.example.com"
+        apps = [app]
+
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+  acl host_test_example_com hdr(host) -i test.example.com
+  use_backend nginx_10000 if host_test_example_com
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+  acl app__nginx hdr(x-marathon-app-id) -i /nginx
+  use_backend nginx_10000 if app__nginx
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+  use_backend nginx_10000 if { ssl_fc_sni test.example.com }
+
+frontend nginx_10000
+  bind *:10000
+  mode http
+  use_backend nginx_10000
+
+backend nginx_10000
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_haproxy_group_fallback(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {}
+        app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app1.groups = ['external', 'internal']
+        app1.add_backend("1.1.1.1", 1024, False)
+        app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        app2.groups = ['external', 'internal']
+        app2.add_backend("1.1.1.1", 1025, False)
+        apps = [app1, app2]
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode tcp
+  use_backend nginx_10000
+
+frontend nginx_10001
+  bind *:10001
+  mode tcp
+  use_backend nginx_10001
+
+backend nginx_10000
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1024 1.1.1.1:1024
+
+backend nginx_10001
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1025 1.1.1.1:1025
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_haproxy_group_per_service(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {}
+        app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app1.haproxy_groups = ['external']
+        app1.add_backend("1.1.1.1", 1024, False)
+        app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        app2.haproxy_groups = ['internal']
+        app2.add_backend("1.1.1.1", 1025, False)
+        apps = [app1, app2]
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode tcp
+  use_backend nginx_10000
+
+backend nginx_10000
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1024 1.1.1.1:1024
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_haproxy_group_hybrid(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {}
+        app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app1.haproxy_groups = ['internal']
+        app1.add_backend("1.1.1.1", 1024, False)
+        app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        app2.groups = ['external']
+        app2.add_backend("1.1.1.1", 1025, False)
+        apps = [app1, app2]
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10001
+  bind *:10001
+  mode tcp
+  use_backend nginx_10001
+
+backend nginx_10001
+  balance roundrobin
+  mode tcp
+  server 1_1_1_1_1025 1.1.1.1:1025
 '''
         self.assertMultiLineEqual(config, expected)


### PR DESCRIPTION
Added support for haproxy group per service port. Currently both service port had to be part of same hagroup group. Now similar to Vhost, we can have different haproxy group per service port. This allows us to have external and internal services running on same box on different service ports, as they can be part of different haproxy group. This supports,

HAPROXY_0_GROUP
HAPROXY_1_GROUP 
and maps them to corresponding service ports.

It is backward compatible as well, so it supports HAPROXY_GROUP.

If both HAPROXY_0_GROUP and HAPROXY_GROUP are specified, the more specific definition takes preference and the service group will be added to HAPROXY_0_GROUP and not HAPROXY_GROUP.

If there are 2 services HAPROXY_0_PORT and HAPROXY_1_PORT and if HAPROXY_0_GROUP and HAPROXY_GROUP labels are defined. HAPROXY_0_PORT service is added to HAPROXY_0_GROUP and HAPROXY_1_PORT is added to HAPROXY_GROUP since HAPROXY_1_GROUP is not specified for it.