### PR TITLE
Add --marathon-auth-credentials option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ option `template-url` to a tarball containing a directory `templates/`.
 See [comments in script](marathon_lb.py) on how to name those.
 
 ### Docker
-Synopsis: `docker run mesosphere/marathon-lb event|poll ...`
+Synopsis: `docker run -e PORT=$portnumber mesosphere/marathon-lb event|poll ...`
+
+You must set `PORT` environment variable to allow haproxy bind to this port.
+Syntax: `docker run PORT=9090 mesosphere/marathon-lb sse [other args]`
 
 You can pass in your own certificates for the SSL frontend by setting
 the `HAPROXY_SSL_CERT` environment variable.
@@ -85,7 +88,12 @@ You can also run the update script directly.
 To generate an HAProxy configuration from Marathon running at `localhost:8080` with the `marathon_lb.py` script, run:
 
 ``` console
-$ ./marathon_lb.py --marathon http://localhost:8080 --haproxy-config /etc/haproxy/haproxy.cfg --group external
+$ ./marathon_lb.py --marathon http://localhost:8080 --group external
+```
+
+It is possible to pass `--marathon-auth-credentials=` option if your Marathon requires authentication:
+```
+$ ./marathon_lb.py --marathon http://localhost:8080 --marathon-auth-credentials=admin:password
 ```
 
 This will refresh `haproxy.cfg`, and if there were any changes, then it will
@@ -103,7 +111,7 @@ $ ./marathon_lb.py --help
 You can provide your SSL certificate paths to be placed in frontend marathon_https_in section with `--ssl-certs`.
 
 ``` console
-$ ./marathon_lb.py --marathon http://localhost:8080 --haproxy-config /etc/haproxy/haproxy.cfg --group external --ssl-certs /etc/ssl/site1.co,/etc/ssl/site2.co
+$ ./marathon_lb.py --marathon http://localhost:8080 --group external --ssl-certs /etc/ssl/site1.co,/etc/ssl/site2.co
 ```
 
 If you are using the script directly, you have two options:
@@ -122,7 +130,7 @@ If you are using the provided `run` script or Docker image, you have three optio
 You can skip the configuration file validation (via calling HAProxy service) process if you don't have HAProxy installed. This is especially useful if you are running HAProxy on Docker containers.
 
 ``` console
-$ ./marathon_lb.py --marathon http://localhost:8080 --haproxy-config /etc/haproxy/haproxy.cfg --group external --skip-validation
+$ ./marathon_lb.py --marathon http://localhost:8080 --group external --skip-validation
 ```
 
 

--- a/common.py
+++ b/common.py
@@ -26,23 +26,32 @@ def set_marathon_auth_args(parser):
                         help="Path to file containing a user/pass for "
                         "the Marathon HTTP API in the format of 'user:pass'."
                         )
+    parser.add_argument("--marathon-auth-credentials",
+                        help="user/pass for the Marathon HTTP API in the "
+                             "format of 'user:pass'.")
 
     return parser
 
 
 def get_marathon_auth_params(args):
-    if args.marathon_auth_credential_file is None:
-        return None
+    marathon_auth = None
+    if args.marathon_auth_credential_file:
+        with open(args.marathon_auth_credential_file, 'r') as f:
+            line = f.readline().rstrip('\r\n')
 
-    line = None
-    with open(args.marathon_auth_credential_file, 'r') as f:
-        line = f.readline().rstrip('\r\n')
+        if line:
+            marathon_auth = tuple(line.split(':'))
+    elif args.marathon_auth_credentials:
+        marathon_auth = \
+            tuple(args.marathon_auth_credentials.split(':'))
 
-    if line is not None:
-        splat = line.split(':')
-        return (splat[0], splat[1])
+    if marathon_auth and len(marathon_auth) != 2:
+        print(
+            "Please provide marathon credentials in user:pass format"
+        )
+        sys.exit(1)
 
-    return None
+    return marathon_auth
 
 
 def set_logging_args(parser):


### PR DESCRIPTION
- this option allows to pass marathon credentials
via docker params
- updated README.md

Signed-off-by: Kiril Nesenko <knesenko@vmware.com>