### PR TITLE
For path ACLs, use backend instead of hostname.

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -163,20 +163,20 @@ class ConfigTemplater(object):
 
     HAPROXY_HTTP_FRONTEND_ACL_WITH_PATH = '''\
   acl host_{cleanedUpHostname} hdr(host) -i {hostname}
-  acl path_{cleanedUpHostname} path_beg {path}
-  use_backend {backend} if host_{cleanedUpHostname} path_{cleanedUpHostname}
+  acl path_{backend} path_beg {path}
+  use_backend {backend} if host_{cleanedUpHostname} path_{backend}
 '''
 
     HAPROXY_HTTP_FRONTEND_ACL_ONLY_WITH_PATH = '''\
-  acl path_{cleanedUpHostname} path_beg {path}
+  acl path_{backend} path_beg {path}
 '''
 
     HAPROXY_HTTPS_FRONTEND_ACL_ONLY_WITH_PATH = '''\
-  acl path_{cleanedUpHostname} path_beg {path}
+  acl path_{backend} path_beg {path}
 '''
 
     HAPROXY_HTTP_FRONTEND_ROUTING_ONLY_WITH_PATH = '''\
-  use_backend {backend} if host_{cleanedUpHostname} path_{cleanedUpHostname}
+  use_backend {backend} if host_{cleanedUpHostname} path_{backend}
 '''
 
     HAPROXY_HTTP_FRONTEND_APPID_ACL = '''\
@@ -189,7 +189,7 @@ class ConfigTemplater(object):
 '''
 
     HAPROXY_HTTPS_FRONTEND_ACL_WITH_PATH = '''\
-  use_backend {backend} if {{ ssl_fc_sni {hostname} }} path_{cleanedUpHostname}
+  use_backend {backend} if {{ ssl_fc_sni {hostname} }} path_{backend}
 '''
 
     HAPROXY_BACKEND_HTTP_OPTIONS = '''\
@@ -955,14 +955,14 @@ def generateHttpVhostAcl(templater, app, backend):
             http_frontend_acl = \
                 templater.haproxy_http_frontend_acl_only_with_path(app)
             staging_http_frontends += http_frontend_acl.format(
-                cleanedUpHostname=acl_name,
-                path=app.path
+                path=app.path,
+                backend=backend
             )
             https_frontend_acl = \
                 templater.haproxy_https_frontend_acl_only_with_path(app)
             staging_https_frontends += https_frontend_acl.format(
-                cleanedUpHostname=acl_name,
-                path=app.path
+                path=app.path,
+                backend=backend
             )
 
         for vhost_hostname in vhosts:

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -375,8 +375,8 @@ frontend marathon_http_in
   bind *:80
   mode http
   acl host_test_example_com hdr(host) -i test.example.com
-  acl path_test_example_com path_beg /some/path
-  use_backend nginx_10000 if host_test_example_com path_test_example_com
+  acl path_nginx_10000 path_beg /some/path
+  use_backend nginx_10000 if host_test_example_com path_nginx_10000
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -435,10 +435,10 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl path_test_example_com path_beg /some/path
+  acl path_nginx_10000 path_beg /some/path
   acl host_test_example_com hdr(host) -i test.example.com
   acl host_test_example_com hdr(host) -i test
-  use_backend nginx_10000 if host_test_example_com path_test_example_com
+  use_backend nginx_10000 if host_test_example_com path_nginx_10000
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -449,10 +449,10 @@ frontend marathon_http_appid_in
 frontend marathon_https_in
   bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
   mode http
-  acl path_test_example_com path_beg /some/path
+  acl path_nginx_10000 path_beg /some/path
   use_backend nginx_10000 if { ssl_fc_sni test.example.com } ''' + \
-                                      '''path_test_example_com
-  use_backend nginx_10000 if { ssl_fc_sni test } path_test_example_com
+                                      '''path_nginx_10000
+  use_backend nginx_10000 if { ssl_fc_sni test } path_nginx_10000
 
 frontend nginx_10000
   bind *:10000


### PR DESCRIPTION
To address #99.