### PR TITLE
fix the haproxy build error in Ubuntu 14.04

### DIFF
--- a/build-haproxy.sh
+++ b/build-haproxy.sh
@@ -25,10 +25,11 @@ make -j4 \
   USE_LINUX_SPLICE=1 \
   USE_LINUX_TPROXY=1 \
   USE_OPENSSL=1 \
+  USE_DL=1 \
   USE_LUA=1 \
   LUA_LIB=/usr/local/lib/ \
   LUA_INC=/usr/local/include/ \
-  LDFLAGS="-lcrypt  -lssl -lcrypto -L/usr/local/lib/ -llua -lm -L/usr/lib -lpcreposix -lpcre -ldl"
+  LDFLAGS="-lcrypt  -lssl -lcrypto -L/usr/local/lib/ -llua -lm -L/usr/lib -lpcreposix -lpcre"
 make -j4 install LDFLAGS="-lcrypt  -lssl -lcrypto -L/usr/local/lib/ -llua -lm -L/usr/lib -lpcreposix -lpcre -ldl"
 
 # Clean up


### PR DESCRIPTION
My system is ubuntu 14.04, the haproxy building get a error.
```

/usr/bin/ld: /usr/local/lib//liblua.a(loadlib.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/libdl.so: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [haproxy] Error 1
```

Add a USE_DL=1 in build options and remove "-ldl" in LDFLAGS was fixed.