### PR TITLE
Need 'stats socket /var/run/haproxy/socket' for seamless reloading

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -82,6 +82,7 @@ class ConfigTemplater(object):
       tune.ssl.default-dh-param 2048
       ssl-default-bind-options no-sslv3 no-tls-tickets force-tlsv12
       ssl-default-bind-ciphers AES128+EECDH:AES128+EDH
+      stats socket /var/run/haproxy/socket
       server-state-file global
       server-state-base /var/state/haproxy/
       lua-load /marathon-lb/getpids.lua

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -13,6 +13,7 @@ class TestMarathonUpdateHaproxy(unittest.TestCase):
   tune.ssl.default-dh-param 2048
   ssl-default-bind-options no-sslv3 no-tls-tickets force-tlsv12
   ssl-default-bind-ciphers AES128+EECDH:AES128+EDH
+  stats socket /var/run/haproxy/socket
   server-state-file global
   server-state-base /var/state/haproxy/
   lua-load /marathon-lb/getpids.lua


### PR DESCRIPTION
It's referred to "http://blog.haproxy.com/2015/10/14/whats-new-in-haproxy-1-6/"