### PR TITLE
Add `/_haproxy_getconfig` endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ All applications are also exposed on port 9091, using the `X-Marathon-App-Id`
 HTTP header. See the documentation for `HAPROXY_HTTP_FRONTEND_APPID_HEAD` in
 the [templates section](#templates)
 
-You can access the HAProxy statistics via `:9090/haproxy?stats`
+You can access the HAProxy statistics via `:9090/haproxy?stats`, and you can
+retrieve the current HAProxy config from the `:9090/_haproxy_getconfig` endpoint.
 
 ## Deployment
 The package is currently available [from the multiverse](https://github.com/mesosphere/multiverse).

--- a/getconfig.lua
+++ b/getconfig.lua
@@ -1,0 +1,39 @@
+-- A simple Lua script which serves up the HAProxy
+-- config as it was at init time.
+
+function read_config_file(cmdline)
+  local found = false
+  local filename = ''
+  for s in string.gmatch(cmdline, '%g+') do
+    if s == '-f' then
+      found = true
+    elseif found then
+      filename = s
+      break
+    end
+  end
+
+  local f = io.open(filename, "rb")
+  local config = f:read("*all")
+  f:close()
+  return config
+end
+
+function load_config()
+  local f = io.open('/proc/self/cmdline', "rb")
+  local cmdline = f:read("*all")
+  f:close()
+  return read_config_file(cmdline)
+end
+
+core.register_init(function()
+  haproxy_config = load_config()
+end)
+
+core.register_service("getconfig", "http", function(applet)
+  applet:set_status(200)
+  applet:add_header("content-length", string.len(haproxy_config))
+  applet:add_header("content-type", "text/plain")
+  applet:start_response()
+  applet:send(haproxy_config)
+end)

--- a/getpids.lua
+++ b/getpids.lua
@@ -3,11 +3,10 @@
 -- the unix `pidof` command.
 -- :)
 
-function os.capture(cmd, raw)
+function os.capture(cmd)
   local f = assert(io.popen(cmd, 'r'))
   local s = assert(f:read('*a'))
   f:close()
-  if raw then return s end
   s = string.gsub(s, '^%s+', '')
   s = string.gsub(s, '%s+$', '')
   s = string.gsub(s, '[\n\r]+', ' ')
@@ -15,7 +14,7 @@ function os.capture(cmd, raw)
 end
 
 core.register_service("getpids", "http", function(applet)
-  response = os.capture("pidof haproxy", false)
+  local response = os.capture("pidof haproxy", false)
   applet:set_status(200)
   applet:add_header("content-length", string.len(response))
   applet:add_header("content-type", "text/plain")

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -86,6 +86,7 @@ class ConfigTemplater(object):
       server-state-file global
       server-state-base /var/state/haproxy/
       lua-load /marathon-lb/getpids.lua
+      lua-load /marathon-lb/getconfig.lua
     defaults
       load-server-state-from-file global
       log               global
@@ -111,6 +112,8 @@ class ConfigTemplater(object):
       monitor-uri /_haproxy_health_check
       acl getpid path /_haproxy_getpids
       http-request use-service lua.getpids if getpid
+      acl getconfig path /_haproxy_getconfig
+      http-request use-service lua.getconfig if getconfig
     ''')
 
     HAPROXY_HTTP_FRONTEND_HEAD = dedent('''

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -17,6 +17,7 @@ class TestMarathonUpdateHaproxy(unittest.TestCase):
   server-state-file global
   server-state-base /var/state/haproxy/
   lua-load /marathon-lb/getpids.lua
+  lua-load /marathon-lb/getconfig.lua
 defaults
   load-server-state-from-file global
   log               global
@@ -42,6 +43,8 @@ listen stats
   monitor-uri /_haproxy_health_check
   acl getpid path /_haproxy_getpids
   http-request use-service lua.getpids if getpid
+  acl getconfig path /_haproxy_getconfig
+  http-request use-service lua.getconfig if getconfig
 '''
 
     def test_config_no_apps(self):


### PR DESCRIPTION
The `/_haproxy_getconfig` returns the HAProxy config as it was at the
time of process initialization.