### PR TITLE
Fix redirect for shared VHosts.

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -974,7 +974,8 @@ def generateHttpVhostAcl(templater, app, backend):
         logger.debug(
             "vhost label specifies multiple hosts: %s", app.hostname)
         vhosts = app.hostname.split(',')
-        acl_name = re.sub(r'[^a-zA-Z0-9\-]', '_', vhosts[0])
+        acl_name = re.sub(r'[^a-zA-Z0-9\-]', '_', vhosts[0]) + \
+            '_' + app.appId[1:].replace('/', '_')
 
         if app.path:
             # Set the path ACL if it exists
@@ -1059,7 +1060,8 @@ def generateHttpVhostAcl(templater, app, backend):
         # A single hostname in the VHOST label
         logger.debug(
             "adding virtual host for app with hostname %s", app.hostname)
-        acl_name = re.sub(r'[^a-zA-Z0-9\-]', '_', app.hostname)
+        acl_name = re.sub(r'[^a-zA-Z0-9\-]', '_', app.hostname) + \
+            '_' + app.appId[1:].replace('/', '_')
 
         if app.path:
             if app.redirectHttpToHttps:

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -257,8 +257,8 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl host_test_example_com hdr(host) -i test.example.com
-  use_backend nginx_10000 if host_test_example_com
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
+  use_backend nginx_10000 if host_test_example_com_nginx
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -316,9 +316,9 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl host_test_example_com hdr(host) -i test.example.com
-  acl host_test_example_com hdr(host) -i test
-  use_backend nginx_10000 if host_test_example_com
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
+  acl host_test_example_com_nginx hdr(host) -i test
+  use_backend nginx_10000 if host_test_example_com_nginx
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -378,8 +378,8 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl host_test_example_com hdr(host) -i test.example.com
-  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
+  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com_nginx
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -438,9 +438,9 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl host_test_example_com hdr(host) -i test.example.com
-  acl host_test_example_com hdr(host) -i test
-  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
+  acl host_test_example_com_nginx hdr(host) -i test
+  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com_nginx
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -500,9 +500,9 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl host_test_example_com hdr(host) -i test.example.com
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
   acl path_nginx_10000 path_beg /some/path
-  use_backend nginx_10000 if host_test_example_com path_nginx_10000
+  use_backend nginx_10000 if host_test_example_com_nginx path_nginx_10000
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -563,9 +563,9 @@ frontend marathon_http_in
   bind *:80
   mode http
   acl path_nginx_10000 path_beg /some/path
-  acl host_test_example_com hdr(host) -i test.example.com
-  acl host_test_example_com hdr(host) -i test
-  use_backend nginx_10000 if host_test_example_com path_nginx_10000
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
+  acl host_test_example_com_nginx hdr(host) -i test
+  use_backend nginx_10000 if host_test_example_com_nginx path_nginx_10000
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -628,9 +628,9 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl host_test_example_com hdr(host) -i test.example.com
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
   acl path_nginx_10000 path_beg /some/path
-  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com\
+  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com_nginx\
  path_nginx_10000
 
 frontend marathon_http_appid_in
@@ -693,9 +693,9 @@ frontend marathon_http_in
   bind *:80
   mode http
   acl path_nginx_10000 path_beg /some/path
-  acl host_test_example_com hdr(host) -i test.example.com
-  acl host_test_example_com hdr(host) -i test
-  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com\
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
+  acl host_test_example_com_nginx hdr(host) -i test
+  redirect scheme https code 301 if !{ ssl_fc } host_test_example_com_nginx\
  path_nginx_10000
 
 frontend marathon_http_appid_in
@@ -925,8 +925,8 @@ backend nginx_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  acl host_test_example_com hdr(host) -i test.example.com
-  use_backend nginx_10000 if host_test_example_com
+  acl host_test_example_com_nginx hdr(host) -i test.example.com
+  use_backend nginx_10000 if host_test_example_com_nginx
 
 frontend marathon_http_appid_in
   bind *:9091


### PR DESCRIPTION
If multiple apps share a VHost, and one uses a redirect but the other
does not, the redirect rule may get applied to the wrong VHost.