### PR TITLE
added in new templates and labels for proxying and redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,18 @@ The full list of labels which can be specified are:
   HAPROXY_{n}_BALANCE
     Set the load balancing algorithm to be used in a backend. The default is roundrobin.
     Ex: HAPROXY_0_BALANCE = 'leastconn'
+    
+  HAPROXY_{0}_HTTP_BACKEND_PROXYPASS
+    Set the location to use for mapping local server URLs to remote servers + URL.
+    Ex: HAPROXY_0_HTTP_BACKEND_PROXYPASS = '/path/to/redirect'
+
+  HAPROXY_{0}_HTTP_BACKEND_REVPROXY
+    Set the URL in HTTP response headers sent from a reverse proxied server. It only updates Location, Content-Location and URL.
+    Ex: HAPROXY_0_HTTP_BACKEND_REVPROXY = '/my/content'
+    
+  HAPROXY_{0}_HTTP_BACKEND_REDIR
+    Set the path to redirect the root of the domain to
+    Ex: HAPROXY_0_HTTP_BACKEND_REDIR = '/my/content'
 ```
 
 ### Templates
@@ -424,6 +436,16 @@ own templates to the Docker image, or provide them at startup.
 
   HAPROXY_FRONTEND_BACKEND_GLUE
     This option glues the backend to the frontend.
+    
+  HAPROXY_HTTP_BACKEND_PROXYPASS 
+    This option enable proxypass features in apache to work
+
+  
+  HAPROXY_HTTP_BACKEND_REVPROXY
+    This option enables reverse proxy option as use in apache to work
+  
+  HAPROXY_HTTP_BACKEND_REDIR 
+    This option enables a simple redirection of the root URL to another location.
 ```
 #### Overridable templates
 

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -598,8 +598,8 @@ label_keys = {
     'HAPROXY_{0}_BACKEND_SERVER_HTTP_HEALTHCHECK_OPTIONS': set_label,
     'HAPROXY_{0}_HTTP_BACKEND_PROXYPASS': set_proxypath,
     'HAPROXY_{0}_HTTP_BACKEND_REVPROXY': set_revproxypath,
-    'HAPROXY_{0}_HTTP_BACKEND_REDIR': set_redirpath
-    'HAPROXY_{0}_FRONTEND_BACKEND_GLUE': set_label,
+    'HAPROXY_{0}_HTTP_BACKEND_REDIR': set_redirpath,
+    'HAPROXY_{0}_FRONTEND_BACKEND_GLUE': set_label
 }
 
 logger = logging.getLogger('marathon_lb')

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -549,14 +549,18 @@ def set_label(x, k, v):
 def set_group(x, k, v):
     x.haproxy_groups = v.split(',')
 
+
 def set_proxypath(x, k, v):
     x.proxypath = v
+
 
 def set_revproxypath(x, k, v):
     x.revproxypath = v
 
+
 def set_redirpath(x, k, v):
     x.redirpath = v
+
 
 label_keys = {
     'HAPROXY_{0}_VHOST': set_hostname,
@@ -885,20 +889,23 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
 
         if app.mode == 'http':
             backends += templater.haproxy_backend_http_options(app)
-            backend_http_backend_proxypass = templater.haproxy_http_backend_proxypass(app)
-            if app.proxypath != '' :
+            backend_http_backend_proxypass = templater \
+                .haproxy_http_backend_proxypass(app)
+            if app.proxypath != '':
                 backends += backend_http_backend_proxypass.format(
                     hostname=app.hostname,
                     proxypath=app.proxypath
                 )
-            backend_http_backend_revproxy = templater.haproxy_http_backend_revproxy(app)
-            if app.revproxypath != '' :
+            backend_http_backend_revproxy = templater \
+                .haproxy_http_backend_revproxy(app)
+            if app.revproxypath != '':
                 backends += backend_http_backend_revproxy.format(
                     hostname=app.hostname,
                     rootpath=app.revproxypath
                 )
-            backend_http_backend_redir = templater.haproxy_http_backend_redir(app)
-            if app.redirpath != '' :
+            backend_http_backend_redir = templater \
+                .haproxy_http_backend_redir(app)
+            if app.redirpath != '':
                 backends += backend_http_backend_redir.format(
                     hostname=app.hostname,
                     redirpath=app.redirpath

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -5,8 +5,6 @@ import marathon_lb
 
 class TestMarathonUpdateHaproxy(unittest.TestCase):
 
-    maxDiff = None
-
     def setUp(self):
         self.base_config = '''global
   daemon


### PR DESCRIPTION
This pull request addresses https://github.com/mesosphere/marathon-lb/issues/75 and additionally adds the ability to redirect the URL root to a subdirectory.

This is a feature that I use on our internal HAProxy for accessing monitoring endpoints rather than for public consumption.