### PR TITLE
Task with no ports silently fails ad stop processing any more apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+tests
+.*
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y python3 python3-pip openssl libssl-dev 
     wget build-essential libpcre3 libpcre3-dev python3-dateutil socat iptables libreadline-dev \
     && pip3 install -r /marathon-lb/requirements.txt \
     && /marathon-lb/build-haproxy.sh \
-    && apt-get remove -yf --auto-remove wget libssl-dev build-essential libpcre3-dev libreadline-dev \
+    && apt-get remove -yf wget libssl-dev build-essential libpcre3-dev libreadline-dev \
+    && apt-get autoremove -yf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /marathon-lb

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1361,7 +1361,7 @@ def get_apps(marathon):
                 marathon_app.app['labels']['HAPROXY_GROUP'].split(',')
         marathon_apps.append(marathon_app)
 
-        service_ports = app.get('ports', [])
+        service_ports = app['ports']
         for i in range(len(service_ports)):
             servicePort = service_ports[i]
             service = MarathonService(
@@ -1395,7 +1395,7 @@ def get_apps(marathon):
                 if not alive:
                     continue
 
-            task_ports = task['ports']
+            task_ports = task.get('ports', [])
             draining = False
             if 'draining' in task:
                 draining = task['draining']

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1361,7 +1361,7 @@ def get_apps(marathon):
                 marathon_app.app['labels']['HAPROXY_GROUP'].split(',')
         marathon_apps.append(marathon_app)
 
-        service_ports = app['ports']
+        service_ports = app.get('ports', [])
         for i in range(len(service_ports)):
             servicePort = service_ports[i]
             service = MarathonService(
@@ -1482,7 +1482,7 @@ class MarathonEventProcessor(object):
                     logger.error("Connection error({0}): {1}".format(
                         e.errno, e.strerror))
                 except:
-                    print("Unexpected error:", sys.exc_info()[0])
+                    logger.exception("Unexpected error!")
 
     def stop(self):
         self.__condition.acquire()


### PR DESCRIPTION
Using marathon there is a chance that a task won't have ports. This fixes a silent failure by exposing the problem by logging the message using the logger instead of print and if ports don't exist we use an empty list.

Symptoms of not fixing this is that not all apps are processed because as soon as any task under any app is found and doesn't have ports it jumps out of the loop and carries on as if nothing is wrong.