### PR TITLE
Bump Debian version from Jessie -> Stretch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 ENTRYPOINT [ "/marathon-lb/run" ]
 CMD        [ "sse", "-m", "http://master.mesos:8080", "--health-check", "--group", "external" ]
@@ -6,7 +6,7 @@ EXPOSE     80 81 443 9090
 
 COPY  . /marathon-lb
 
-RUN apt-get update && apt-get install -y python3 python3-pip openssl libssl-dev runit \
+RUN apt-get update && apt-get install -y python3 python3-pip openssl libssl-dev runit procps \
     wget build-essential libpcre3 libpcre3-dev python3-dateutil socat iptables libreadline-dev \
     && pip3 install -r /marathon-lb/requirements.txt \
     && /marathon-lb/build-haproxy.sh \


### PR DESCRIPTION
This will give us OpenSSL 1.0.2, among other things, which has better
support for hardware acceleration of TLS.