### PR TITLE
Replaced serverName with shortHashedServerName in haproxy configs if …

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -413,7 +413,8 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
             serverName = re.sub(
                 r'[^a-zA-Z0-9\-]', '_',
                 backendServer.host + '_' + str(backendServer.port))
-
+            shortHashedServerName = hashlib.sha1(serverName.encode()).hexdigest()[:10]
+            
             healthCheckOptions = None
             if app.healthCheck:
                 server_health_check_options = None
@@ -457,7 +458,7 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
                     port=backendServer.port,
                     serverName=serverName,
                     cookieOptions=' check cookie ' +
-                    serverName if app.sticky else '',
+                    shortHashedServerName if app.sticky else '',
                     healthCheckOptions=healthCheckOptions
                     if healthCheckOptions else '',
                     otherOptions=' disabled' if backendServer.draining else ''


### PR DESCRIPTION
…sticky options are used, so as not to leak information about hostnames/ports