### PR TITLE
Replaced serverName with shortHashedServerName in haproxy configs if ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Marathon-lb is a tool for managing HAProxy, by consuming [Marathon's](https://gi
 
  * [Using marathon-lb](https://docs.mesosphere.com/administration/service-discovery/service-discovery-and-load-balancing-with-marathon-lb/service-discovery-and-load-balancing/)
  * [Advanced features of marathon-lb](https://docs.mesosphere.com/administration/service-discovery/service-discovery-and-load-balancing-with-marathon-lb/advanced-features-of-marathon-lb/)
+ * [Securing your service with TLS/SSL (blog post)](https://mesosphere.com/blog/2016/04/06/lets-encrypt-dcos/)
 
 ## Architecture
 The marathon-lb script `marathon_lb.py` connects to the marathon API
@@ -138,6 +139,18 @@ You can skip the configuration file validation (via calling HAProxy service) pro
 ``` console
 $ ./marathon_lb.py --marathon http://localhost:8080 --group external --skip-validation
 ```
+
+### API endpoints
+
+Marathon-lb exposes a few endpoints on port 9090 (by default). They are:
+
+| Endpoint                      | Description                                                                                                                                                                                                                                                                                                               |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `:9090/haproxy?stats`         | HAProxy stats endpoint. This produces an HTML page which can be viewed in your browser, providing various statistics about the current HAProxy instance.                                                                                                                                                                  |
+| `:9090/haproxy?stats;csv`     | This is a CSV version of the stats above, which can be consumed by other tools. For example, it's used in the [`bluegreen_deploy.py`](bluegreen_deploy.py) script.                                                                                                                                                        |
+| `:9090/_haproxy_health_check` | HAProxy health check endpoint. Returns `200 OK` if HAProxy is healthy.                                                                                                                                                                                                                                                    |
+| `:9090/_haproxy_getconfig`    | Returns the HAProxy config file as it was when HAProxy was started. Implemented in [`getconfig.lua`](getconfig.lua).                                                                                                                                                                                                      |
+| `:9090/_haproxy_getpids`      | Returns the PIDs for all HAProxy instances within the current process namespace. This literally returns `$(pidof haproxy)`. Implemented in [`getpids.lua`](getpids.lua). This is also used by the [`bluegreen_deploy.py`](bluegreen_deploy.py) script to determine if connections have finished draining during a deploy. |
 
 
 ## HAProxy configuration

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -47,6 +47,7 @@ import dateutil.parser
 import math
 import threading
 import random
+import hashlib
 
 logger = logging.getLogger('marathon_lb')
 
@@ -413,6 +414,8 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
             serverName = re.sub(
                 r'[^a-zA-Z0-9\-]', '_',
                 backendServer.host + '_' + str(backendServer.port))
+            shortHashedServerName = hashlib.sha1(serverName.encode()) \
+                .hexdigest()[:10]
 
             healthCheckOptions = None
             if app.healthCheck:
@@ -457,7 +460,7 @@ def config(apps, groups, bind_http_https, ssl_certs, templater):
                     port=backendServer.port,
                     serverName=serverName,
                     cookieOptions=' check cookie ' +
-                    serverName if app.sticky else '',
+                    shortHashedServerName if app.sticky else '',
                     healthCheckOptions=healthCheckOptions
                     if healthCheckOptions else '',
                     otherOptions=' disabled' if backendServer.draining else ''

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -1340,3 +1340,45 @@ backend nginx_10000
   server 1_1_1_1_1024 1.1.1.1:1024
 '''
         self.assertMultiLineEqual(config, expected)
+
+    def test_config_simple_app_sticky(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {}
+        app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app.groups = ['external']
+        app.add_backend("1.1.1.1", 1024, False)
+        app.sticky = True
+        apps = [app]
+
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode tcp
+  use_backend nginx_10000
+
+backend nginx_10000
+  balance roundrobin
+  mode tcp
+  cookie mesosphere_server_id insert indirect nocache
+  server 1_1_1_1_1024 1.1.1.1:1024 check cookie b270c76538
+'''
+        self.assertMultiLineEqual(config, expected)


### PR DESCRIPTION
…sticky options are used, so as not to leak information about hostnames/ports