### PR TITLE
Allow LB to work for apps with IP per task

### DIFF
--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -162,7 +162,7 @@ frontend marathon_https_in
         }
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -195,7 +195,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -221,7 +221,7 @@ backend nginx_10000
         }
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -247,7 +247,7 @@ frontend nginx_10000
 backend nginx_10000
   balance roundrobin
   mode tcp
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -271,7 +271,7 @@ backend nginx_10000
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.hostname = "test.example.com"
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -307,7 +307,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -391,7 +391,7 @@ backend nginx_10000
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.hostname = "test.example.com"
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         app.redirectHttpToHttps = True
         apps = [app]
 
@@ -428,7 +428,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -514,7 +514,7 @@ backend nginx_10000
         app.hostname = "test.example.com"
         app.path = '/some/path'
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -552,7 +552,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -641,7 +641,7 @@ backend nginx_10000
         app.hostname = "test.example.com"
         app.path = '/some/path'
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         app.redirectHttpToHttps = True
         apps = [app]
 
@@ -681,7 +681,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -839,7 +839,7 @@ backend nginx_10000
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.balance = "leastconn"
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -872,7 +872,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -951,7 +951,7 @@ backend nginx_10000
         }
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -984,7 +984,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11 port 1024
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11 port 1024
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1006,7 +1006,7 @@ backend nginx_10000
         }
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         app.hostname = "test.example.com"
         apps = [app]
 
@@ -1041,7 +1041,7 @@ backend nginx_10000
   option forwardfor
   http-request set-header X-Forwarded-Port %[dst_port]
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
-  server 1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1055,10 +1055,10 @@ backend nginx_10000
         healthCheck = {}
         app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app1.groups = ['external', 'internal']
-        app1.add_backend("1.1.1.1", 1024, False)
+        app1.add_backend("agent1", "1.1.1.1", 1024, False)
         app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
         app2.groups = ['external', 'internal']
-        app2.add_backend("1.1.1.1", 1025, False)
+        app2.add_backend("agent1", "1.1.1.1", 1025, False)
         apps = [app1, app2]
         config = marathon_lb.config(apps, groups, bind_http_https,
                                     ssl_certs, templater)
@@ -1088,12 +1088,12 @@ frontend nginx_10001
 backend nginx_10000
   balance roundrobin
   mode tcp
-  server 1_1_1_1_1024 1.1.1.1:1024
+  server agent1_1_1_1_1_1024 1.1.1.1:1024
 
 backend nginx_10001
   balance roundrobin
   mode tcp
-  server 1_1_1_1_1025 1.1.1.1:1025
+  server agent1_1_1_1_1_1025 1.1.1.1:1025
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1107,10 +1107,10 @@ backend nginx_10001
         healthCheck = {}
         app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app1.haproxy_groups = ['external']
-        app1.add_backend("1.1.1.1", 1024, False)
+        app1.add_backend("agent1", "1.1.1.1", 1024, False)
         app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
         app2.haproxy_groups = ['internal']
-        app2.add_backend("1.1.1.1", 1025, False)
+        app2.add_backend("agent1", "1.1.1.1", 1025, False)
         apps = [app1, app2]
         config = marathon_lb.config(apps, groups, bind_http_https,
                                     ssl_certs, templater)
@@ -1135,7 +1135,7 @@ frontend nginx_10000
 backend nginx_10000
   balance roundrobin
   mode tcp
-  server 1_1_1_1_1024 1.1.1.1:1024
+  server agent1_1_1_1_1_1024 1.1.1.1:1024
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1149,10 +1149,10 @@ backend nginx_10000
         healthCheck = {}
         app1 = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app1.haproxy_groups = ['internal']
-        app1.add_backend("1.1.1.1", 1024, False)
+        app1.add_backend("agent1", "1.1.1.1", 1024, False)
         app2 = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
         app2.groups = ['external']
-        app2.add_backend("1.1.1.1", 1025, False)
+        app2.add_backend("agent1", "1.1.1.1", 1025, False)
         apps = [app1, app2]
         config = marathon_lb.config(apps, groups, bind_http_https,
                                     ssl_certs, templater)
@@ -1177,7 +1177,7 @@ frontend nginx_10001
 backend nginx_10001
   balance roundrobin
   mode tcp
-  server 1_1_1_1_1025 1.1.1.1:1025
+  server agent1_1_1_1_1_1025 1.1.1.1:1025
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1195,7 +1195,7 @@ backend nginx_10001
         app.groups = ['external']
         app.hostname = 'test.example.com'
         app.proxypath = '/test/'
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -1231,7 +1231,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   http-request set-header Host test.example.com
   reqirep  "^([^ :]*)\ /test/(.*)" "\\1\ /\\2"
-  server 1_1_1_1_1024 1.1.1.1:1024
+  server agent1_1_1_1_1_1024 1.1.1.1:1024
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1247,7 +1247,7 @@ backend nginx_10000
         app.groups = ['external']
         app.hostname = 'test.example.com'
         app.revproxypath = '/test'
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -1284,7 +1284,7 @@ backend nginx_10000
   acl hdr_location res.hdr(Location) -m found
   rspirep "^Location: (https?://test.example.com(:[0-9]+)?)?(/.*)" "Location: \
   /test if hdr_location"
-  server 1_1_1_1_1024 1.1.1.1:1024
+  server agent1_1_1_1_1_1024 1.1.1.1:1024
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1300,7 +1300,7 @@ backend nginx_10000
         app.groups = ['external']
         app.hostname = 'test.example.com'
         app.redirpath = '/test'
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -1337,7 +1337,7 @@ backend nginx_10000
   acl is_root path -i /
   acl is_domain hdr(host) -i test.example.com
   redirect code 301 location /test if is_domain is_root
-  server 1_1_1_1_1024 1.1.1.1:1024
+  server agent1_1_1_1_1_1024 1.1.1.1:1024
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1351,7 +1351,7 @@ backend nginx_10000
         healthCheck = {}
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.groups = ['external']
-        app.add_backend("1.1.1.1", 1024, False)
+        app.add_backend("agent1", "1.1.1.1", 1024, False)
         app.sticky = True
         apps = [app]
 
@@ -1379,6 +1379,6 @@ backend nginx_10000
   balance roundrobin
   mode tcp
   cookie mesosphere_server_id insert indirect nocache
-  server 1_1_1_1_1024 1.1.1.1:1024 check cookie b270c76538
+  server agent1_1_1_1_1_1024 1.1.1.1:1024 check cookie b270c76538
 '''
         self.assertMultiLineEqual(config, expected)


### PR DESCRIPTION
-  Fix up LB to use correct IP address and port.  For IP-per-task, use actual task IP and port.
-  Workaround Marathon issue where service port is not returned for IP-per-task apps.  The
   workaround is to auto assign a local port on the LB.  Only useful when using vhost since
   the port is not exposed anywhere, so use of DNS entries is required.

This PR does not yet include any UT updates - I didn't want to make any until the function was actually reviewed.

Fixes #139 
Works around Marathon issue: https://github.com/mesosphere/marathon/issues/3636

To workaround the Marathon issue where service ports are not returned for IP-per-task applications I've implemented a ServicePortAssigner that will assign an arbitrary local port to use for a particular application.  Ports are only auto-assigned if the app is IP-per-task and the --min-serv-port-ip-per-task and --max-serv-port-ip-per-task port range is specified (to prevent clashes with service ports assigned by Marathon).  It's only useful if you are using vhost and therefore accessing apps by name since this auto-assigned port is not exposed and is not persistent upon restart.

I can put up a PR that removes all the service port shenanigans if you'd prefer, but until Marathon is fixed to return the service ports it still won't be much use.  I've tried to implement this so that when Marathon is fixes it will just start doing the right thing.