### PR TITLE
Auto-assign service ports for IP-per-container tasks when Marathon does not

### DIFF
--- a/Longhelp.md
+++ b/Longhelp.md
@@ -25,6 +25,8 @@ usage: marathon_lb.py [-h] [--longhelp] [--marathon MARATHON [MARATHON ...]]
                       [--lru-cache-capacity LRU_CACHE_CAPACITY]
                       [--dont-bind-http-https] [--ssl-certs SSL_CERTS]
                       [--skip-validation] [--dry]
+                      [--min-serv-port-ip-per-task MIN_SERV_PORT_IP_PER_TASK]
+                      [--max-serv-port-ip-per-task MAX_SERV_PORT_IP_PER_TASK]
                       [--syslog-socket SYSLOG_SOCKET]
                       [--log-format LOG_FORMAT]
                       [--marathon-auth-credential-file MARATHON_AUTH_CREDENTIAL_FILE]
@@ -73,9 +75,15 @@ optional arguments:
                         /etc/ssl/mesosphere.com.pem)
   --skip-validation     Skip haproxy config file validation (default: False)
   --dry, -d             Only print configuration to console (default: False)
+  --min-serv-port-ip-per-task MIN_SERV_PORT_IP_PER_TASK
+                        Minimum port number to use when auto-assigning service
+                        ports for IP-per-task applications (default: 10050)
+  --max-serv-port-ip-per-task MAX_SERV_PORT_IP_PER_TASK
+                        Maximum port number to use when auto-assigning service
+                        ports for IP-per-task applications (default: 10100)
   --syslog-socket SYSLOG_SOCKET
                         Socket to write syslog messages to. Use '/dev/null' to
-                        disable logging to syslog (default: /var/run/syslog)
+                        disable logging to syslog (default: /dev/log)
   --log-format LOG_FORMAT
                         Set log message format (default: %(name)s:
                         %(message)s)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ the [templates section](Longhelp.md#templates)
 You can access the HAProxy statistics via `:9090/haproxy?stats`, and you can
 retrieve the current HAProxy config from the `:9090/_haproxy_getconfig` endpoint.
 
+Marathon LB supports load balancing for applications that use the Mesos IP-per-task
+feature, whereby each task is assigned unique, accessible, IP addresses.  For these
+tasks services are directly accessible via the configured discovery ports and there
+is no host port mapping.  Note, that due to limitations with Marathon (see 
+[mesosphere/marathon#3636](https://github.com/mesosphere/marathon/issues/3636)) 
+configured service ports are not exposed to Marathon LB for IP-per-task apps.  
+For these apps, where the service ports are missing from the Marathon app data,
+Marathon LB will automatically assign port values from a configurable range.  The range
+is configured using the `--min-serv-port-ip-per-task` and `--max-serv-port-ip-per-task`
+options.
+
 ## Deployment
 The package is currently available [from the universe](https://github.com/mesosphere/universe).
 To deploy marathon-lb on the public slaves in your DCOS cluster,

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Marathon-lb is a tool for managing HAProxy, by consuming [Marathon's](https://gi
  * DCOS integration
  * Automated Docker image builds ([mesosphere/marathon-lb](https://hub.docker.com/r/mesosphere/marathon-lb))
  * Global HAProxy templates which can be supplied at launch
+ * Supports IP-per-task integration, such as [Project Calico](https://github.com/projectcalico/calico-containers)
 
 ### Getting started
 
@@ -43,17 +44,6 @@ the [templates section](Longhelp.md#templates)
 
 You can access the HAProxy statistics via `:9090/haproxy?stats`, and you can
 retrieve the current HAProxy config from the `:9090/_haproxy_getconfig` endpoint.
-
-Marathon LB supports load balancing for applications that use the Mesos IP-per-task
-feature, whereby each task is assigned unique, accessible, IP addresses.  For these
-tasks services are directly accessible via the configured discovery ports and there
-is no host port mapping.  Note, that due to limitations with Marathon (see 
-[mesosphere/marathon#3636](https://github.com/mesosphere/marathon/issues/3636)) 
-configured service ports are not exposed to Marathon LB for IP-per-task apps.  
-For these apps, where the service ports are missing from the Marathon app data,
-Marathon LB will automatically assign port values from a configurable range.  The range
-is configured using the `--min-serv-port-ip-per-task` and `--max-serv-port-ip-per-task`
-options.
 
 ## Deployment
 The package is currently available [from the universe](https://github.com/mesosphere/universe).
@@ -247,6 +237,19 @@ An example minimal configuration for a [test instance of nginx is included here]
 ```
 
 Zero downtime deployments are accomplished through the use of a Lua module, which reports the number of HAProxy processes which are currently running by hitting the stats endpoint at the `/_haproxy_getpids`. After a restart, there will be multiple HAProxy PIDs until all remaining connections have gracefully terminated. By waiting for all connections to complete, you may safely and deterministically drain tasks. A caveat of this, however, is that if you have any long-lived connections on the same LB, HAProxy will continue to run and serve those connections until they complete, thereby breaking this technique.
+
+## Mesos with IP-per-task support
+
+Marathon-lb supports load balancing for applications that use the Mesos IP-per-task
+feature, whereby each task is assigned unique, accessible, IP addresses.  For these
+tasks services are directly accessible via the configured discovery ports and there
+is no host port mapping.  Note, that due to limitations with Marathon (see 
+[mesosphere/marathon#3636](https://github.com/mesosphere/marathon/issues/3636)) 
+configured service ports are not exposed to marathon-lb for IP-per-task apps.  
+For these apps, if the service ports are missing from the Marathon app data,
+marathon-lb will automatically assign port values from a configurable range.  The range
+is configured using the `--min-serv-port-ip-per-task` and `--max-serv-port-ip-per-task`
+options.
 
 ## Contributing
 

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1041,6 +1041,10 @@ def get_apps(marathon):
 
         service_ports = SERVICE_PORT_ASSIGNER.get_service_ports(app)
         for i, servicePort in enumerate(service_ports):
+            if servicePort is None:
+                logger.warning("Skipping undefined service port")
+                continue
+
             service = MarathonService(
                         appId, servicePort, get_health_check(app, i))
 
@@ -1353,14 +1357,18 @@ if __name__ == '__main__':
                 'either specify both --min-serv-port-ip-per-task '
                 'and --max-serv-port-ip-per-task or neither (set both to zero '
                 'to disable auto assignment)')
+        if args.min_serv_port_ip_per_task > args.max_serv_port_ip_per_task:
+            arg_parser.error(
+                'cannot set --min-serv-port-ip-per-task to a higher value '
+                'than --max-serv-port-ip-per-task')
         if len(args.group) == 0:
             arg_parser.error('argument --group is required: please' +
                              'specify at least one group name')
 
     # Configure the service port assigner if min/max ports have been specified.
     if args.min_serv_port_ip_per_task and args.max_serv_port_ip_per_task:
-        SERVICE_PORT_ASSIGNER.set_ports(int(args.min_serv_port_ip_per_task),
-                                        int(args.max_serv_port_ip_per_task))
+        SERVICE_PORT_ASSIGNER.set_ports(args.min_serv_port_ip_per_task,
+                                        args.max_serv_port_ip_per_task)
 
     # Set request retries
     s = requests.Session()

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -1,6 +1,5 @@
 import unittest
 import json
-from mock import patch
 import marathon_lb
 
 
@@ -1684,66 +1683,3 @@ backend nginx_10000
   server agent1_1_1_1_1_1024 1.1.1.1:1024 check cookie d6ad48c81f
 '''
         self.assertMultiLineEqual(config, expected)
-
-    def test_get_task_ip_and_ports_ip_per_task(self):
-        app = {
-            "ipAddress": {
-                "discovery": {
-                    "ports": [{"number": 123}, {"number": 234}]
-                }
-            },
-        }
-        task = {
-            "id": "testtaskid",
-            "ipAddresses": [{"ipAddress": "1.2.3.4"}]
-        }
-
-        result = marathon_lb.get_task_ip_and_ports(app, task)
-        expected = ("1.2.3.4", [123, 234])
-
-        self.assertEquals(result, expected)
-
-    def test_get_task_ip_and_ports_ip_per_task_no_ip(self):
-        app = {
-            "ipAddress": {
-                "discovery": {
-                    "ports": [{"number": 123}, {"number": 234}]
-                }
-            },
-        }
-        task = {
-            "id": "testtaskid"
-        }
-
-        result = marathon_lb.get_task_ip_and_ports(app, task)
-        expected = (None, None)
-
-        self.assertEquals(result, expected)
-
-    def test_get_task_ip_and_ports_port_map(self):
-        app = {}
-        task = {
-            "id": "testtaskid",
-            "ports": [234, 345, 567],
-            "host": "agent1"
-        }
-
-        with patch("marathon_lb.resolve_ip", return_value="1.2.3.4"):
-            result = marathon_lb.get_task_ip_and_ports(app, task)
-            expected = ("1.2.3.4", [234, 345, 567])
-
-        self.assertEquals(result, expected)
-
-    def test_get_task_ip_and_ports_port_map_no_ip(self):
-        app = {}
-        task = {
-            "id": "testtaskid",
-            "ports": [234, 345, 567],
-            "host": "agent1"
-        }
-
-        with patch("marathon_lb.resolve_ip", return_value=None):
-            result = marathon_lb.get_task_ip_and_ports(app, task)
-            expected = (None, None)
-
-            self.assertEquals(result, expected)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+import hashlib
+import struct
+import logging
+import socket
+
+logger = logging.getLogger('utils')
+
+# The maximum number of clashes to allow when assigning a port.
+MAX_CLASHES = 50
+
+
+class ServicePortAssigner(object):
+    """
+    Helper class to assign service ports.
+
+    Ordinarily Marathon should assign the service ports, but Marathon issue
+    https://github.com/mesosphere/marathon/issues/3636 means that service
+    ports are not returned for applications using IP-per-task.  We work around
+    that here by assigning deterministic ports from a configurable range when
+    required.
+
+    Note that auto-assigning ports is only useful when using vhost: the ports
+    that we assign here are not exposed to the client.
+
+    The LB command line options --min-serv-port-ip-per-task and
+    --max-serv-port-ip-per-task specify the allowed range of ports to
+    auto-assign from.  The range of ports used for auto-assignment should be
+    selected to ensure no clashes with the exposed LB ports and the
+    Marathon-assigned services ports.
+
+    The service port assigner provides a mechanism to auto assign service ports
+    using the application name to generate service port (while preventing
+    clashes when the port is already claimed by another app).  The assigner
+    provides a deterministic set of ports for a given ordered set of port
+    requests.
+    """
+    def __init__(self):
+        self.min_port = None
+        self.max_port = None
+        self.max_ports = None
+        self.can_assign = False
+        self.next_port = None
+        self.ports_by_app = {}
+
+    def _assign_new_service_port(self, app, task_port):
+        assert self.can_assign
+
+        remaining_ports = self.max_ports - len(self.ports_by_app)
+        assert remaining_ports, "Service ports are exhausted"
+
+        # We don't want to be searching forever, so limit the number of times
+        # we clash to the number of remaining ports.
+        ports = self.ports_by_app.values()
+        port = None
+        for i in range(MAX_CLASHES):
+            hash_str = "%s-%s-%s" % (app['id'], task_port, i)
+            hash_val = hashlib.sha1(hash_str.encode("utf-8")).hexdigest()
+            hash_int = int(hash_val[:8], 16)
+            trial_port = self.min_port + (hash_int % self.max_ports)
+            if trial_port not in ports:
+                port = trial_port
+                break
+        if port is None:
+            for port in range(self.min_port, self.max_port + 1):
+                if port not in ports:
+                    break
+
+        # We must have assigned a unique port by now since we know there were
+        # some available.
+        assert port and port not in ports
+
+        logger.debug("Assigned new port: %d", port)
+        return port
+
+    def _get_service_port(self, app, task_port):
+        key = (app['id'], task_port)
+        port = (self.ports_by_app.get(key) or
+                self._assign_new_service_port(app, task_port))
+        self.ports_by_app[key] = port
+        return port
+
+    def set_ports(self, min_port, max_port):
+        """
+        Set the range of ports that we can use for auto-assignment of
+        service ports - just for IP-per-task apps.
+        :param min_port: The minimum port value
+        :param max_port: The maximum port value
+        """
+        self.min_port = min_port
+        self.max_port = max_port
+        self.max_ports = max_port - min_port + 1
+        self.can_assign = self.min_port and self.max_port
+        assert not self.ports_by_app
+        assert self.max_ports > 1
+
+    def reset(self):
+        """
+        Reset the assigner so that ports are newly assigned.
+        :return:
+        """
+        self.ports_by_app = {}
+
+    def get_service_ports(self, app):
+        ports = app['ports']
+        if not ports and is_ip_per_task(app) and self.can_assign:
+            logger.warning("Auto assigning service port for "
+                           "IP-per-container task")
+            task = app['tasks'][0]
+            _, task_ports = get_task_ip_and_ports(app, task)
+            ports = [self._get_service_port(app, task_port)
+                     for task_port in task_ports]
+        logger.debug("Service ports: %r", ports)
+        return ports
+
+
+def resolve_ip(host):
+    cached_ip = ip_cache.get(host, None)
+    if cached_ip:
+        return cached_ip
+    else:
+        try:
+            logger.debug("trying to resolve ip address for host %s", host)
+            ip = socket.gethostbyname(host)
+            ip_cache[host] = ip
+            return ip
+        except socket.gaierror:
+            return None
+ip_cache = dict()
+
+
+def is_ip_per_task(app):
+    """
+    Return whether the application is using IP-per-task.
+    :param app:  The application to check.
+    :return:  True if using IP per task, False otherwise.
+    """
+    return app.get('ipAddress') is not None
+
+
+def get_task_ip_and_ports(app, task):
+    """
+    Return the IP address and list of ports used to access a task.  For a
+    task using IP-per-task, this is the IP address of the task, and the ports
+    exposed by the task services.  Otherwise, this is the IP address of the
+    host and the ports exposed by the host.
+    :param app: The application owning the task.
+    :param task: The task.
+    :return: Tuple of (ip address, [ports]).  Returns (None, None) if no IP
+    address could be resolved or found for the task.
+    """
+    # If the app ipAddress field is present and not None then this app is using
+    # IP per task.  The ipAddress may be an empty dictionary though, in which
+    # case there are no discovery ports.  At the moment, Mesos only supports a
+    # single IP address, so just take the first IP in the list.
+    if is_ip_per_task(app):
+        logger.debug("Using IP per container")
+        task_ip_addresses = task.get('ipAddresses')
+        if not task_ip_addresses:
+            logger.warning("Task %s does not yet have an ip address allocated",
+                           task['id'])
+            return None, None
+        task_ip = task_ip_addresses[0]['ipAddress']
+
+        discovery = app['ipAddress'].get('discovery', {})
+        task_ports = [int(port['number'])
+                      for port in discovery.get('ports', [])]
+    else:
+        logger.debug("Using host port mapping")
+        task_ports = task.get('ports', [])
+        task_ip = resolve_ip(task['host'])
+        if not task_ip:
+            logger.warning("Could not resolve ip for host %s, ignoring",
+                           task['host'])
+            return None, None
+
+    logger.debug("Returning: %r, %r", task_ip, task_ports)
+    return task_ip, task_ports


### PR DESCRIPTION
The following Marathon LB fix is a workaround for a Marathon issue: https://github.com/mesosphere/marathon/issues/3636

The above issue means Marathon does not return service ports when using apps with IP-per-task.  Upshot is Marathon-LB does not work for these apps.

Ideally, I'd really like to see a fix for the above issue, but I'm offering this PR as a temporary work-around.

The change in this PR auto-assigns a service port for each host discovery port when the app is using IP-per-task.  The ports are not persistent across restart of the marathon-lb process, and the ports are not exposed so this fix is only useful when using vhost (where you don't actually care what value of service port is chosen).  The feature is activated by specifying a min/max port as additional arguments - these ports should be chosen so that they don't clash with the service ports assigned by Marathon.