### PR TITLE
Add basic LRU cache for health status.

### DIFF
--- a/Longhelp.md
+++ b/Longhelp.md
@@ -22,6 +22,7 @@ usage: marathon_lb.py [-h] [--longhelp] [--marathon MARATHON [MARATHON ...]]
                       [--listening LISTENING] [--callback-url CALLBACK_URL]
                       [--haproxy-config HAPROXY_CONFIG] [--group GROUP]
                       [--command COMMAND] [--sse] [--health-check]
+                      [--lru-cache-capacity LRU_CACHE_CAPACITY]
                       [--dont-bind-http-https] [--ssl-certs SSL_CERTS]
                       [--skip-validation] [--dry]
                       [--syslog-socket SYSLOG_SOCKET]
@@ -58,6 +59,10 @@ optional arguments:
   --health-check, -H    If set, respect Marathon's health check statuses
                         before adding the app instance into the backend pool.
                         (default: False)
+  --lru-cache-capacity LRU_CACHE_CAPACITY
+                        Health check result LRU cache size (in number of
+                        items). This should be at least as large as the number
+                        of tasks exposed via marathon-lb. (default: 1000)
   --dont-bind-http-https
                         Don't bind to HTTP and HTTPS frontends. (default:
                         False)

--- a/lrucache.py
+++ b/lrucache.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+"""
+A simple LRU cache based on the one described at:
+https://www.kunxi.org/blog/2014/05/lru-cache-in-python/
+"""
+import collections
+
+
+class LRUCache:
+    def __init__(self, capacity=100):
+        self.capacity = capacity
+        self.cache = collections.OrderedDict()
+
+    def get(self, key, default):
+        try:
+            value = self.cache.pop(key)
+            self.cache[key] = value
+            return value
+        except KeyError:
+            return default
+
+    def set(self, key, value):
+        try:
+            self.cache.pop(key)
+        except KeyError:
+            if len(self.cache) >= self.capacity:
+                self.cache.popitem(last=False)
+        self.cache[key] = value

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -29,6 +29,7 @@ from six.moves.urllib import parse
 from itertools import cycle
 from common import *
 from config import *
+from lrucache import *
 
 import argparse
 import json
@@ -789,6 +790,8 @@ def get_health_check(app, portIndex):
             return check
     return None
 
+healthCheckResultCache = LRUCache()
+
 
 def get_apps(marathon):
     apps = marathon.list()
@@ -916,14 +919,18 @@ def get_apps(marathon):
 
             if marathon.health_check() and 'healthChecks' in app and \
                len(app['healthChecks']) > 0:
-                if 'healthCheckResults' not in task:
-                    continue
                 alive = True
-                for result in task['healthCheckResults']:
-                    if not result['alive']:
-                        alive = False
-                if not alive:
-                    continue
+                if 'healthCheckResults' not in task:
+                    # use previously cached result, if it exists
+                    if not healthCheckResultCache.get(task['id'], False):
+                        continue
+                else:
+                    for result in task['healthCheckResults']:
+                        if not result['alive']:
+                            alive = False
+                    healthCheckResultCache.set(task['id'], alive)
+                    if not alive:
+                        continue
 
             task_ports = task.get('ports', [])
             draining = False
@@ -1076,6 +1083,12 @@ def get_arg_parser():
                         "statuses before adding the app instance into "
                         "the backend pool.",
                         action="store_true")
+    parser.add_argument("--lru-cache-capacity",
+                        help="Health check result LRU cache size (in number "
+                        "of items). This should be at least as large as the "
+                        "number of tasks exposed via marathon-lb.",
+                        type=int, default=1000
+                        )
     parser.add_argument("--dont-bind-http-https",
                         help="Don't bind to HTTP and HTTPS frontends.",
                         action="store_true")
@@ -1192,6 +1205,10 @@ if __name__ == '__main__':
 
     # Setup logging
     setup_logging(logger, args.syslog_socket, args.log_format)
+
+    # initialize health check LRU cache
+    if args.health_check:
+        healthCheckResultCache = LRUCache(args.lru_cache_capacity)
 
     # Marathon API connector
     marathon = Marathon(args.marathon,


### PR DESCRIPTION
When Marathon fails over, it will come back up without any task health
information. Unfortunately, this will cause marathon-lb to treat the
backends as being down, and will remove them. With this, we keep around
an LRU cache of task health states to reduce the likeliness of removing
backends after a failover by reusing the previously known health state.