### PR TITLE
Optionally make sysctl setting a soft failure.

### DIFF
--- a/run
+++ b/run
@@ -46,6 +46,16 @@ if [ -n "${MESOS_SANDBOX-}" ] && [ -d "$MESOS_SANDBOX/templates" ]; then
   cp -v "$MESOS_SANDBOX/templates/"* templates/
 fi
 
+if [ -n "${HAPROXY_SYSCTL_PARAMS-}" ]; then
+  echo "setting sysctl params to: ${HAPROXY_SYSCTL_PARAMS}"
+  if [ -n "${HAPROXY_SYSCTL_NONSTRICT-}" ]; then
+    # ignore errors
+    sysctl -w $HAPROXY_SYSCTL_PARAMS || true
+  else
+    sysctl -w $HAPROXY_SYSCTL_PARAMS
+  fi
+fi
+
 /usr/bin/runsv "$HAPROXY_SERVICE" &
 RUNSV=$!
 ARGS=""
@@ -74,11 +84,6 @@ case "$MODE" in
     exit 1
     ;;
 esac
-
-if [ -n "${HAPROXY_SYSCTL_PARAMS-}" ]; then
-  echo "setting sysctl params to: ${HAPROXY_SYSCTL_PARAMS}"
-  sysctl -w $HAPROXY_SYSCTL_PARAMS
-fi
 
 while true; do
   /marathon-lb/marathon_lb.py \


### PR DESCRIPTION
By default, if `systcl` fails it results in a hard failure. In other
words, the main `run` script will exit and the container will fail.

By setting `HAPROXY_SYSCTL_NONSTRICT` to a non-empty string, the
`sysctl` failures will be treated as soft failures.

This was introduced to workaround in issue where Docker will mount /proc
within the container as read-only, even when the container is running in
privileged mode.

cc @lingmann @alberts