### PR TITLE
Allow to specify multiple certs in Docker ENV

### DIFF
--- a/run
+++ b/run
@@ -9,35 +9,49 @@ mkdir -p $HAPROXY_SERVICE/env
 if [ -n "${PORTS-}" ]; then
   echo $PORTS > $HAPROXY_SERVICE/env/PORTS
 else
-  echo "Define $PORTS with a comma-separated list of ports to which HAProxy binds" >&2
+  echo 'Define $PORTS with a comma-separated list of ports to which HAProxy binds' >&2
   exit 1
 fi
 
-# Iterate through the arguments to see if any SSL certificate is provided.
-for key in "$@"
-do
-
-case $key in
-    --ssl-certs)
-    SSL_CERTS="yes"
-    ;;
-    *)
-            # unknown option
-    ;;
-esac
+# Find the --ssl-certs arg if one was provided,
+# get the certs and remove them and the arg from the list
+# of positional parameters so we don't duplicate them
+# further down when we pass $@ to marathon_lb.py
+declare -i ssl_certs_pos=0
+for ((i=1; i<=$#; i++)); do
+  if [ ${!i} = '--ssl-certs' ]; then
+    ssl_certs_pos=$(($i+1))
+    break
+  fi
 done
-
+if [ $ssl_certs_pos -gt 0 ]; then
+  SSL_CERTS=${!ssl_certs_pos}
+  set -- "${@:1:$(($ssl_certs_pos-2))}" "${@:$(($ssl_certs_pos+1))}"
+  [ -n "${HAPROXY_SSL_CERT-}" ] && SSL_CERTS+=",/etc/ssl/cert.pem"
+else
+  SSL_CERTS="/etc/ssl/cert.pem"
+fi
 
 if [ -n "${HAPROXY_SSL_CERT-}" ]; then
   # if provided via environment variable, use it.
-  echo -e "$HAPROXY_SSL_CERT" > /etc/ssl/mesosphere.com.pem
-elif ! [ -n "${SSL_CERTS-}" ]; then
+  echo -e "$HAPROXY_SSL_CERT" > /etc/ssl/cert.pem
+
+  # if additional certs were provided as $HAPROXY_SSL_CERT0 .. 100
+  for i in {0..100}; do
+    certenv="HAPROXY_SSL_CERT$i"
+    if [ -n "${!certenv-}" ]; then
+      certfile="/etc/ssl/cert$i.pem"
+      echo -e "${!certenv}" > $certfile
+      SSL_CERTS+=",$certfile"
+    fi
+  done
+elif [ $ssl_certs_pos -eq 0 ]; then  # if --ssl-certs wasn't passed as arg to this script
   # if no environment variable or command line argument is provided,
   # create self-signed ssl certificate
   openssl genrsa -out /tmp/server-key.pem 2048
   openssl req -new -key /tmp/server-key.pem -out /tmp/server-csr.pem -subj /CN=*/
   openssl x509 -req -in /tmp/server-csr.pem -out /tmp/server-cert.pem -signkey /tmp/server-key.pem -days 3650
-  cat /tmp/server-cert.pem /tmp/server-key.pem > /etc/ssl/mesosphere.com.pem
+  cat /tmp/server-cert.pem /tmp/server-key.pem > /etc/ssl/cert.pem
   rm /tmp/server-*.pem
 fi
 
@@ -89,7 +103,8 @@ while true; do
   /marathon-lb/marathon_lb.py \
     --syslog-socket $SYSLOG_SOCKET \
     --haproxy-config /marathon-lb/haproxy.cfg \
-    -c "sv reload $HAPROXY_SERVICE" \
+    --ssl-certs "$SSL_CERTS" \
+    --command "sv reload $HAPROXY_SERVICE" \
     $ARGS "$@" &
   wait $! || exit $? # Needed for the traps to work
   if [ "$MODE" != "poll" ]; then

--- a/run
+++ b/run
@@ -14,48 +14,32 @@ else
 fi
 
 # Iterate through the arguments to see if any SSL certificate is provided.
-prev=0
 for key in "$@"
 do
 
-case $prev in
+case $key in
     --ssl-certs)
-      SSL_CERTS=$key
+    SSL_CERTS="yes"
     ;;
     *)
             # unknown option
     ;;
 esac
-prev=$key
 done
+
 
 if [ -n "${HAPROXY_SSL_CERT-}" ]; then
   # if provided via environment variable, use it.
-  echo -e "$HAPROXY_SSL_CERT" > /etc/ssl/cert.pem
-  if [ -n "${SSL_CERTS-}" ]; then
-    SSL_CERTS+=",/etc/ssl/cert.pem"
-  else
-    SSL_CERTS="/etc/ssl/cert.pem"
-  fi
+  echo -e "$HAPROXY_SSL_CERT" > /etc/ssl/mesosphere.com.pem
 elif ! [ -n "${SSL_CERTS-}" ]; then
   # if no environment variable or command line argument is provided,
   # create self-signed ssl certificate
   openssl genrsa -out /tmp/server-key.pem 2048
   openssl req -new -key /tmp/server-key.pem -out /tmp/server-csr.pem -subj /CN=*/
   openssl x509 -req -in /tmp/server-csr.pem -out /tmp/server-cert.pem -signkey /tmp/server-key.pem -days 3650
-  cat /tmp/server-cert.pem /tmp/server-key.pem > /etc/ssl/cert.pem
+  cat /tmp/server-cert.pem /tmp/server-key.pem > /etc/ssl/mesosphere.com.pem
   rm /tmp/server-*.pem
-  SSL_CERTS="/etc/ssl/cert.pem"
 fi
-
-for i in {0..100}; do
-  certenv="HAPROXY_SSL_CERT$i"
-  if [ -n "${!certenv-}" ]; then
-    certfile="/etc/ssl/cert$i.pem"
-    echo -e "${!certenv}" > $certfile
-    SSL_CERTS+=",$certfile"
-  fi
-done
 
 if [ -n "${MESOS_SANDBOX-}" ] && [ -d "$MESOS_SANDBOX/templates" ]; then
   mkdir -p templates
@@ -105,8 +89,7 @@ while true; do
   /marathon-lb/marathon_lb.py \
     --syslog-socket $SYSLOG_SOCKET \
     --haproxy-config /marathon-lb/haproxy.cfg \
-    --ssl-certs $SSL_CERTS \
-    --command "sv reload $HAPROXY_SERVICE" \
+    -c "sv reload $HAPROXY_SERVICE" \
     $ARGS "$@" &
   wait $! || exit $? # Needed for the traps to work
   if [ "$MODE" != "poll" ]; then


### PR DESCRIPTION
This is the same PR as https://github.com/mesosphere/marathon-lb/pull/169 with a fix for the issue reported in https://github.com/mesosphere/marathon-lb/pull/170 as well as a fix for the situation where `--ssl-certs` would be passed to `marathon_lb.py` twice.

This should now allow any combination of passing certificates either on the commandline and/or as ENV vars or not at all resulting in the self-signed cert being generated.

Also moved the loop that looks for additional certificates (`$HAPROXY_SSL_CERT0` - `$HAPROXY_SSL_CERT100`) into the if check for `$HAPROXY_SSL_CERT` since it doesn't make any sense to have a system with user provided as well as a self signed certificate. This way a user has to explicitly set `$HAPROXY_SSL_CERT` for his first certificate and only then can add additional certs using `$HAPROXY_SSL_CERT0..`

I also fixed a bug where `echo "Define $PORTS with a comma-separated list of ports to which HAProxy binds"` would try to expand `$PORTS` instead of printing it.