### PR TITLE
Refactor `process_json` and `get_app_info` in bluegreen_deploy.py

### DIFF
--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -53,10 +53,15 @@ def query_yes_no(question, default="yes"):
                              "(or 'y' or 'n').\n")
 
 
-def list_marathon_apps(args):
-    url = args.marathon + "/v2/apps"
+def marathon_get_request(args, path):
+    url = args.marathon + path
     response = requests.get(url, auth=get_marathon_auth_params(args))
     response.raise_for_status()
+    return response
+
+
+def list_marathon_apps(args):
+    response = marathon_get_request(args, "/v2/apps")
     return response.json()
 
 

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -358,6 +358,16 @@ def validate_app(app):
                         )
 
 
+def set_app_ids(app, colour):
+    app['labels']['HAPROXY_APP_ID'] = app['id']
+    app['id'] = app['id'] + '-' + colour
+
+    if app['id'][0] != '/':
+        app['id'] = '/' + app['id']
+
+    return app
+
+
 def process_json(args, out=sys.stdout):
     with open(args.json, 'r') as content_file:
         content = content_file.read()
@@ -369,7 +379,6 @@ def process_json(args, out=sys.stdout):
 
     deployment_group = app['labels']['HAPROXY_DEPLOYMENT_GROUP']
     alt_port = app['labels']['HAPROXY_DEPLOYMENT_ALT_PORT']
-    app['labels']['HAPROXY_APP_ID'] = app_id
 
     service_port = get_service_port(app)
 
@@ -377,10 +386,8 @@ def process_json(args, out=sys.stdout):
         get_app_info(args, deployment_group, alt_port)
 
     app = set_service_port(app, port)
+    app = set_app_ids(app, colour)
 
-    app['id'] = app_id + "-" + colour
-    if app['id'][0] != '/':
-        app['id'] = '/' + app['id']
     if existing_app is not None:
         app['instances'] = args.initial_instances
         app['labels']['HAPROXY_DEPLOYMENT_TARGET_INSTANCES'] = \

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -331,14 +331,12 @@ def get_service_port(app):
         return app['ports'][0]
 
 
-def set_service_port(app, port):
-    if 'container' in app and \
-            'docker' in app['container'] and \
-            'portMappings' in app['container']['docker']:
-        app['container']['docker']['portMappings'][0]['servicePort'] = \
-            int(port)
-        return app
-    app['ports'][0] = int(servicePort)
+def set_service_port(app, servicePort):
+    try:
+        app['container']['docker']['portMappings'][0]['servicePort'] = int(servicePort)
+    except KeyError:
+        app['ports'][0] = int(servicePort)
+
     return app
 
 

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -53,11 +53,15 @@ def query_yes_no(question, default="yes"):
                              "(or 'y' or 'n').\n")
 
 
-def get_app_info(args, deployment_group, alt_port):
+def list_marathon_apps(args):
     url = args.marathon + "/v2/apps"
     response = requests.get(url, auth=get_marathon_auth_params(args))
     response.raise_for_status()
-    apps = response.json()
+    return response.json()
+
+
+def get_app_info(args, deployment_group, alt_port):
+    apps = list_marathon_apps(args)
     existing_app = None
     colour = 'blue'
     next_port = alt_port

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -420,7 +420,8 @@ def process_json(args, out=sys.stdout):
         # There is a stuck deploy, oh no!
         if args.resume:
             logger.info("Found previous deployment, resuming")
-            old_deploy, current_deploy = select_last_two_deploys(previous_deploys)
+            old_deploy, current_deploy = \
+                select_last_two_deploys(previous_deploys)
             start_deployment(args, current_deploy, old_deploy, True)
         else:
             raise Exception("There appears to be an"

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -325,13 +325,10 @@ def start_deployment(args, app, existing_app, resuming):
 
 
 def get_service_port(app):
-    if 'container' in app and \
-            'docker' in app['container'] and \
-            'portMappings' in app['container']['docker']:
-        portMappings = app['container']['docker']['portMappings']
-        # Just take the first servicePort
-        return portMappings[0]['servicePort']
-    return app['ports'][0]
+    try:
+        return app['container']['docker']['portMappings'][0]['servicePort']
+    except KeyError:
+        return app['ports'][0]
 
 
 def set_service_port(app, port):

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -368,9 +368,9 @@ def process_json(args, out=sys.stdout):
         content = content_file.read()
 
     app = json.loads(content)
+    validate_app(app)
 
     app_id = app['id']
-    validate_app(app)
 
     deployment_group = app['labels']['HAPROXY_DEPLOYMENT_GROUP']
     alt_port = app['labels']['HAPROXY_DEPLOYMENT_ALT_PORT']

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -65,6 +65,11 @@ def list_marathon_apps(args):
     return response.json()
 
 
+def fetch_marathon_app(args, app_ip):
+    response = marathon_get_request(args, "/v2/apps" + app_id)
+    return response.json()['app']
+
+
 def get_app_info(args, deployment_group, alt_port):
     apps = list_marathon_apps(args)
     existing_app = None
@@ -340,14 +345,8 @@ def set_service_port(app, port):
     return app
 
 
-def process_json(args, out=sys.stdout):
-    with open(args.json, 'r') as content_file:
-        content = content_file.read()
-
-    app = json.loads(content)
-
-    app_id = app['id']
-    if app_id is None:
+def validate_app(app):
+    if app['id'] is None:
         raise Exception("App doesn't contain a valid App ID")
 
     if 'labels' not in app:
@@ -362,6 +361,16 @@ def process_json(args, out=sys.stdout):
         raise Exception("Please define the "
                         "HAPROXY_DEPLOYMENT_ALT_PORT label"
                         )
+
+
+def process_json(args, out=sys.stdout):
+    with open(args.json, 'r') as content_file:
+        content = content_file.read()
+
+    app = json.loads(content)
+
+    app_id = app['id']
+    validate_app(app)
 
     deployment_group = app['labels']['HAPROXY_DEPLOYMENT_GROUP']
     alt_port = app['labels']['HAPROXY_DEPLOYMENT_ALT_PORT']


### PR DESCRIPTION
It was previously very hard to understand what was happening in the `bluegreen_deploy.py` script with the looping constructs in `process_json` and `get_app_info`, instead refactor these methods to be more straight forward and readable.