### PR TITLE
correct bug when scaling app instances

### DIFF
--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -307,14 +307,14 @@ def waiting_for_drained_listeners(listeners):
 
 
 def scale_new_app_instances(args, new_app, old_app):
-    """Scale the app by 150% of its existing instances until we hit the
+    """Scale the app by 150% of its existing instances until we
        meet or surpase old_app instances. At which point go right to
        the new_app deployment target
     """
     instances = (math.floor(new_app['instances'] +
                  (new_app['instances'] + 1) / 2))
     if instances >= old_app['instances']:
-        instances = get_deployment_target(new_app)  # If we've eclipsed old_app
+        instances = get_deployment_target(new_app)
 
     logger.info("Scaling new app up to {} instances".format(instances))
     return scale_marathon_app_instances(args, new_app, instances)

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -307,9 +307,9 @@ def waiting_for_drained_listeners(listeners):
 
 
 def scale_new_app_instances(args, new_app, old_app):
-    """Scale the app by 150% of its existing instances until we
-       meet or surpase old_app instances. At which point go right to
-       the new_app deployment target
+    """Scale the app by 50% of its existing instances until we
+       meet or surpass instances deployed for old_app.
+       At which point go right to the new_app deployment target
     """
     instances = (math.floor(new_app['instances'] +
                  (new_app['instances'] + 1) / 2))

--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -285,7 +285,7 @@ def swap_bluegreen_apps(args, new_app, old_app, timestamp):
                             "\n  - ".join(drained_task_ids)))
 
         if args.force or query_yes_no("Continue?"):
-            scale_up_app_instances(args, new_app)
+            scale_new_app_instances(args, new_app, old_app)
 
             # Kill any drained tasks
             logger.info("Scaling down old app by {} instances"
@@ -306,16 +306,18 @@ def waiting_for_drained_listeners(listeners):
     return len(select_drained_listeners(listeners)) < 1
 
 
-def scale_up_app_instances(args, app):
+def scale_new_app_instances(args, new_app, old_app):
     """Scale the app by 150% of its existing instances until we hit the
-       deployment target
+       meet or surpase old_app instances. At which point go right to
+       the new_app deployment target
     """
-    instances = math.floor(app['instances'] + (app['instances'] + 1) / 2)
-    if instances >= app['instances']:
-        instances = get_deployment_target(app)  # Don't go past the target
+    instances = (math.floor(new_app['instances'] +
+                 (new_app['instances'] + 1) / 2))
+    if instances >= old_app['instances']:
+        instances = get_deployment_target(new_app)  # If we've eclipsed old_app
 
     logger.info("Scaling new app up to {} instances".format(instances))
-    scale_marathon_app_instances(args, app, instances)
+    return scale_marathon_app_instances(args, new_app, instances)
 
 
 def safe_delete_app(args, app):

--- a/tests/test_bluegreen_deploy.py
+++ b/tests/test_bluegreen_deploy.py
@@ -34,6 +34,44 @@ def _load_listeners():
 
 class TestBluegreenDeploy(unittest.TestCase):
 
+    @mock.patch('bluegreen_deploy.scale_marathon_app_instances')
+    """When scaling new_app instances, increase instances by 50% of existing
+       instances if we have not yet met or surpassed the amount of instances
+       deployed by old_app
+    """
+    def test_scale_new_app_instances_up_50_percent(self, mock):
+        new_app = {
+            'instances': 10,
+            'labels': {
+                'HAPROXY_DEPLOYMENT_TARGET_INSTANCES': 30
+            }
+        }
+        old_app = {'instances': 30}
+        args = Arguments()
+        args.initial_instances = 5
+        bluegreen_deploy.scale_new_app_instances(args, new_app, old_app)
+        mock.assert_called_with(
+          args, new_app, 15)
+
+    @mock.patch('bluegreen_deploy.scale_marathon_app_instances')
+    def test_scale_new_app_instances_to_target(self, mock):
+      """When scaling new instances up, if we have met or surpassed the amount
+         of instances deployed for old_app, go right to our deployment target
+         amount of instances for new_app
+      """
+        new_app = {
+            'instances': 10,
+            'labels': {
+                'HAPROXY_DEPLOYMENT_TARGET_INSTANCES': 30
+            }
+        }
+        old_app = {'instances': 8}
+        args = Arguments()
+        args.initial_instances = 5
+        bluegreen_deploy.scale_new_app_instances(args, new_app, old_app)
+        mock.assert_called_with(
+          args, new_app, 30)
+
     def test_find_drained_task_ids(self):
         listeners = _load_listeners()
         haproxy_instance_count = 2

--- a/tests/test_bluegreen_deploy.py
+++ b/tests/test_bluegreen_deploy.py
@@ -55,10 +55,10 @@ class TestBluegreenDeploy(unittest.TestCase):
 
     @mock.patch('bluegreen_deploy.scale_marathon_app_instances')
     def test_scale_new_app_instances_to_target(self, mock):
-      """When scaling new instances up, if we have met or surpassed the amount
-         of instances deployed for old_app, go right to our deployment target
-         amount of instances for new_app
-      """
+        """When scaling new instances up, if we have met or surpassed the amount
+           of instances deployed for old_app, go right to our deployment target
+           amount of instances for new_app
+        """
         new_app = {
             'instances': 10,
             'labels': {

--- a/tests/test_bluegreen_deploy.py
+++ b/tests/test_bluegreen_deploy.py
@@ -36,9 +36,9 @@ class TestBluegreenDeploy(unittest.TestCase):
 
     @mock.patch('bluegreen_deploy.scale_marathon_app_instances')
     def test_scale_new_app_instances_up_50_percent(self, mock):
-        """When scaling new_app instances, increase instances by 50% of existing
-           instances if we have not yet met or surpassed the amount of instances
-           deployed by old_app
+        """When scaling new_app instances, increase instances by 50% of
+           existing instances if we have not yet met or surpassed the amount
+           of instances deployed by old_app
         """
         new_app = {
             'instances': 10,
@@ -55,9 +55,9 @@ class TestBluegreenDeploy(unittest.TestCase):
 
     @mock.patch('bluegreen_deploy.scale_marathon_app_instances')
     def test_scale_new_app_instances_to_target(self, mock):
-        """When scaling new instances up, if we have met or surpassed the amount
-           of instances deployed for old_app, go right to our deployment target
-           amount of instances for new_app
+        """When scaling new instances up, if we have met or surpassed the
+           amount of instances deployed for old_app, go right to our
+           deployment target amount of instances for new_app
         """
         new_app = {
             'instances': 10,

--- a/tests/test_bluegreen_deploy.py
+++ b/tests/test_bluegreen_deploy.py
@@ -35,11 +35,11 @@ def _load_listeners():
 class TestBluegreenDeploy(unittest.TestCase):
 
     @mock.patch('bluegreen_deploy.scale_marathon_app_instances')
-    """When scaling new_app instances, increase instances by 50% of existing
-       instances if we have not yet met or surpassed the amount of instances
-       deployed by old_app
-    """
     def test_scale_new_app_instances_up_50_percent(self, mock):
+        """When scaling new_app instances, increase instances by 50% of existing
+           instances if we have not yet met or surpassed the amount of instances
+           deployed by old_app
+        """
         new_app = {
             'instances': 10,
             'labels': {


### PR DESCRIPTION
Small bug fix 😦 

~~We need to compare 150% of instances when scaling against the
old_app (previously existing_app) instances. otherwise we always
scale to deployment target on first go.~~

Update: Better explanation added below...

rename scale_up_app_instances to scale_new_app_instances to avoid
confusion.