### PR TITLE
correct and add test for `swap_bluegreen_apps` timeout

### DIFF
--- a/bluegreen_deploy.py
+++ b/bluegreen_deploy.py
@@ -14,6 +14,7 @@ import re
 import math
 import six.moves.urllib as urllib
 import socket
+import sys
 
 
 logger = logging.getLogger('bluegreen_deploy')
@@ -490,7 +491,7 @@ def safe_resume_deploy(args, previous_deploys):
     if args.resume:
         logger.info("Found previous deployment, resuming")
         new_app, old_app = select_last_two_deploys(previous_deploys)
-        swap_bluegreen_apps(args, new_app, old_app, time.time())
+        return swap_bluegreen_apps(args, new_app, old_app, time.time())
     else:
         raise Exception("There appears to be an"
                         " existing deployment in progress")
@@ -609,4 +610,7 @@ if __name__ == '__main__':
     set_request_retries()
     setup_logging(logger, args.syslog_socket, args.log_format)
 
-    do_bluegreen_deploy(args)
+    if do_bluegreen_deploy(args):
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/tests/test_bluegreen_deploy.py
+++ b/tests/test_bluegreen_deploy.py
@@ -2,7 +2,7 @@ import unittest
 import bluegreen_deploy
 import mock
 import json
-
+import time
 
 class Arguments:
     json = 'tests/1-nginx.json'
@@ -130,6 +130,19 @@ class TestBluegreenDeploy(unittest.TestCase):
         assert 'http://127.0.0.1:9090' in marathon_lb_urls
         assert 'http://127.0.0.2:9090' in marathon_lb_urls
         assert 'http://127.0.0.3:9090' not in marathon_lb_urls
+
+    @mock.patch('bluegreen_deploy.logger')
+    def test_swap_bluegreen_apps_timeout(self, logger):
+        args = Arguments()
+        args.max_wait = 10
+        timestamp = time.time() - 15
+
+        response = bluegreen_deploy.swap_bluegreen_apps(args, {}, {},
+                                                             timestamp)
+
+        logger.info.assert_called_with('Timed out when waiting for backends'
+                                       ' to drain!')
+        assert response == False
 
     @mock.patch('requests.get',
                 mock.Mock(side_effect=lambda k, auth:

--- a/tests/test_bluegreen_deploy.py
+++ b/tests/test_bluegreen_deploy.py
@@ -4,6 +4,7 @@ import mock
 import json
 import time
 
+
 class Arguments:
     json = 'tests/1-nginx.json'
     force = False
@@ -138,11 +139,11 @@ class TestBluegreenDeploy(unittest.TestCase):
         timestamp = time.time() - 15
 
         response = bluegreen_deploy.swap_bluegreen_apps(args, {}, {},
-                                                             timestamp)
+                                                        timestamp)
 
         logger.info.assert_called_with('Timed out when waiting for backends'
                                        ' to drain!')
-        assert response == False
+        assert response is False
 
     @mock.patch('requests.get',
                 mock.Mock(side_effect=lambda k, auth:


### PR DESCRIPTION
@brndnmtthws This tests that when `args.max_wait` is exceeded, the function `swap_bluegreen_apps` will log the timeout and return false instead of throwing an exception. (thus allowing the script to exit naturally) This is done by using the new method `max_wait_not_exceeded` as the condition for the `while` loop in `swap_bluegreen_apps`. This means that a timeout will only happen after a full iteration of the `while` loop, ensuring we are not left with any undeleted tasks which we know about.

As well since we no longer raise an exception on timeout I've simply set the scripts exit code based on the return value of `do_bluegreen_deploy`. This allows the script to exit gracefully on timeout but with a non-zero exit code to indicate failure.

This should prevent an infinite loop due to catching the Timeout exception and never exiting from the `while True` loop.