### PR TITLE
Add network_allow ACLs to HTTP and TCP backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
   - "3.4"
   - "3.5"
 script: nosetests
-install: "pip install -r requirements.txt pep8"
+install: "pip install -r requirements.txt"

--- a/Longhelp.md
+++ b/Longhelp.md
@@ -83,7 +83,7 @@ optional arguments:
                         ports for IP-per-task applications (default: 10100)
   --syslog-socket SYSLOG_SOCKET
                         Socket to write syslog messages to. Use '/dev/null' to
-                        disable logging to syslog (default: /var/run/syslog)
+                        disable logging to syslog (default: /dev/log)
   --log-format LOG_FORMAT
                         Set log message format (default: %(name)s:
                         %(message)s)
@@ -520,6 +520,32 @@ glues the acl names to the appropriate backend
   http-request auth realm "{realm}" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}
   use_backend {backend} if host_{cleanedUpHostname} path_{backend}
 ```
+## `HAPROXY_HTTP_BACKEND_ACL_ALLOW_DENY`
+  *Global*
+
+Specified as `HAPROXY_HTTP_BACKEND_ACL_ALLOW_DENY` template.
+
+This option denies all IPs (or IP ranges) not explicitly allowed to access the HTTP backend.
+Use with HAPROXY_HTTP_BACKEND_NETWORK_ALLOWED_ACL.
+
+
+**Default template for `HAPROXY_HTTP_BACKEND_ACL_ALLOW_DENY`:**
+```
+  http-request allow if network_allowed
+  http-request deny
+```
+## `HAPROXY_HTTP_BACKEND_NETWORK_ALLOWED_ACL`
+  *Overridable*
+
+Specified as `HAPROXY_HTTP_BACKEND_NETWORK_ALLOWED_ACL` template or with label `HAPROXY_{n}_HTTP_BACKEND_NETWORK_ALLOWED_ACL`.
+
+This option set the IPs (or IP ranges) having access to the HTTP backend.
+
+
+**Default template for `HAPROXY_HTTP_BACKEND_NETWORK_ALLOWED_ACL`:**
+```
+  acl network_allowed src {network_allowed}
+```
 ## `HAPROXY_HTTP_BACKEND_PROXYPASS`
   *Overridable*
 
@@ -777,6 +803,32 @@ glues the acl names to the appropriate backend
   http-request auth realm "{realm}" if host_{cleanedUpHostname} path_{backend} !auth_{cleanedUpHostname}
   use_backend {backend} if host_{cleanedUpHostname} path_{backend}
 ```
+## `HAPROXY_TCP_BACKEND_ACL_ALLOW_DENY`
+  *Global*
+
+Specified as `HAPROXY_TCP_BACKEND_ACL_ALLOW_DENY` template.
+
+This option denies all IPs (or IP ranges) not explicitly allowed to access the TCP backend.
+Use with HAPROXY_TCP_BACKEND_ACL_ALLOW_DENY.
+
+
+**Default template for `HAPROXY_TCP_BACKEND_ACL_ALLOW_DENY`:**
+```
+  tcp-request content accept if network_allowed
+  tcp-request content reject
+```
+## `HAPROXY_TCP_BACKEND_NETWORK_ALLOWED_ACL`
+  *Overridable*
+
+Specified as `HAPROXY_TCP_BACKEND_NETWORK_ALLOWED_ACL` template or with label `HAPROXY_{n}_TCP_BACKEND_NETWORK_ALLOWED_ACL`.
+
+This option set the IPs (or IP ranges) having access to the TCP backend.
+
+
+**Default template for `HAPROXY_TCP_BACKEND_NETWORK_ALLOWED_ACL`:**
+```
+  acl network_allowed src {network_allowed}
+```
 ## `HAPROXY_USERLIST_HEAD`
   *Overridable*
 
@@ -802,6 +854,16 @@ Specified as `HAPROXY_{n}_AUTH`.
 The http basic auth definition.
 
 Ex: `HAPROXY_0_AUTH = realm:username:encryptedpassword`
+
+## `HAPROXY_{n}_BACKEND_NETWORK_ALLOWED_ACL`
+  *per service port*
+
+Specified as `HAPROXY_{n}_BACKEND_NETWORK_ALLOWED_ACL`.
+
+Set the IPs (or IP ranges) having access to the backend. By default every IP is allowed.
+
+Ex: `HAPROXY_0_BACKEND_NETWORK_ALLOWED_ACL = '127.0.0.1/8, 10.1.55.43'`
+                    
 
 ## `HAPROXY_{n}_BACKEND_WEIGHT`
   *per service port*

--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ path from where the script is run. Some templates can also be
 [overridden _per app service port_](#overridable-templates). You may add your
 own templates to the Docker image, or provide them at startup.
 
-
 See [the configuration doc for the full list](Longhelp.md#templates)
 of templates.
 
@@ -287,7 +286,7 @@ feature, whereby each task is assigned unique, accessible, IP addresses.  For th
 tasks services are directly accessible via the configured discovery ports and there
 is no host port mapping.  Note, that due to limitations with Marathon (see
 [mesosphere/marathon#3636](https://github.com/mesosphere/marathon/issues/3636))
-configured service ports are not exposed to marathon-lb for IP-per-task apps.  
+configured service ports are not exposed to marathon-lb for IP-per-task apps.
 
 For these apps, if the service ports are missing from the Marathon app data,
 marathon-lb will automatically assign port values from a configurable range.  The range

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests
 six
 python-dateutil
+pep8
+mock


### PR DESCRIPTION
This PR add the ability to define a set of trusted IPs or networks to an http or tcp backend per port or globally.

Example: 
```json
$  cat marathon.json 
{
  "id": "nginx",
  "mem": 128.0,
  "cpus": 0.5,
  "instances": 1,
  "labels": {
    "HAPROXY_0_MODE": "http",
    "HAPROXY_0_BACKEND_NETWORK_ALLOWED_ACL": "127.0.0.1 192.168.0.1/25",
    "HAPROXY_GROUP": "*"
  },
  "container": {
    "docker": {
      "portMappings": [
        {
          "servicePort": 0,
          "protocol": "tcp",
          "containerPort": 443,
          "hostPort": 0
        },
        {
          "servicePort": 0,
          "protocol": "tcp",
          "containerPort": 80,
          "hostPort": 0
        }
      ],
      "image": "nginx",
      "network": "BRIDGE",
      "priviledged": false
    },
    "type": "DOCKER",
    "volumes": []
  },
  "healthChecks": [
    {
      "portIndex": 0,
      "protocol": "TCP",
      "timeoutSeconds": 20,
      "intervalSeconds": 60,
      "gracePeriodSeconds": 300,
      "maxConsecutiveFailures": 3
    },
    {
      "portIndex": 1,
      "protocol": "TCP",
      "timeoutSeconds": 20,
      "intervalSeconds": 60,
      "gracePeriodSeconds": 300,
      "maxConsecutiveFailures": 3
    }
  ]
}
```


Resulting HA proxy configuration : 
```
<HAproxy header>
frontend marathon_http_in
  bind *:80
  mode http

frontend marathon_http_appid_in
  bind *:9091
  mode http
  acl app__nginx hdr(x-marathon-app-id) -i /nginx
  use_backend nginx_10000 if app__nginx

frontend marathon_https_in
  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
  mode http

frontend nginx_10000
  bind *:10000
  mode http
  use_backend nginx_10000

frontend nginx_10001
  bind *:10001
  mode tcp
  use_backend nginx_10001

backend nginx_10000
  balance roundrobin
  mode http
  option forwardfor
  http-request set-header X-Forwarded-Port %[dst_port]
  http-request add-header X-Forwarded-Proto https if { ssl_fc }
  acl network_allowed src 127.0.0.1
  acl network_allowed src 192.168.0.1/25
  http-request allow if network_allowed
  http-request deny
  server dev-timothee_localdomain_127_0_1_1_31830 127.0.1.1:31830 check inter 60s fall 4

backend nginx_10001
  balance roundrobin
  mode tcp
  server dev-timothee_localdomain_127_0_1_1_31831 127.0.1.1:31831 check inter 60s fall 4

```