### PR TITLE
Changed zdd to work with svnames generated by haproxy

### DIFF
--- a/tests/test_zdd.py
+++ b/tests/test_zdd.py
@@ -79,9 +79,9 @@ class TestBluegreenDeploy(unittest.TestCase):
         haproxy_instance_count = 2
         apps = json.loads(open('tests/zdd_app_blue.json').read())
         app = apps['apps'][0]
-
+        args = Arguments()
         results = \
-            zdd.find_drained_task_ids(app,
+            zdd.find_drained_task_ids(args, app,
                                       listeners,
                                       haproxy_instance_count)
 
@@ -94,9 +94,9 @@ class TestBluegreenDeploy(unittest.TestCase):
         haproxy_instance_count = 2
         apps = json.loads(open('tests/zdd_app_blue.json').read())
         app = apps['apps'][0]
-
+        args = Arguments()
         results = \
-            zdd.find_draining_task_ids(app,
+            zdd.find_draining_task_ids(args, app,
                                        listeners,
                                        haproxy_instance_count)
 
@@ -107,11 +107,17 @@ class TestBluegreenDeploy(unittest.TestCase):
     def test_get_svnames_from_tasks(self):
         apps = json.loads(open('tests/zdd_app_blue.json').read())
         tasks = apps['apps'][0]['tasks']
-
-        task_svnames = zdd.get_svnames_from_tasks(tasks)
+        args = Arguments()
+        task_svnames = zdd.get_svnames_from_tasks(args, tasks)
 
         assert '10_0_6_25_172_17_1_72_16916' in task_svnames
         assert '10_0_6_25_172_17_1_71_31184' in task_svnames
+        assert '10_0_6_25_23336' in task_svnames
+
+        args.no_ip_per_container = True
+        task_svnames = zdd.get_svnames_from_tasks(args, tasks)
+        assert '10_0_6_25_16916' in task_svnames
+        assert '10_0_6_25_31184' in task_svnames
         assert '10_0_6_25_23336' in task_svnames
 
     def test_parse_haproxy_stats(self):

--- a/zdd.py
+++ b/zdd.py
@@ -205,21 +205,26 @@ def _get_task_ipaddress(task):
         return task['host']
 
 
-def get_svnames_from_task(task):
+def get_svnames_from_task(args, task):
     prefix = task['host'].replace('.', '_')
     task_ip = _get_task_ipaddress(task)
     if task['host'] == task_ip:
         for port in task['ports']:
             yield('{}_{}'.format(prefix, port))
     else:
-        for port in task['ports']:
-            yield('{}_{}_{}'.format(prefix, task_ip.replace('.', '_'), port))
+        if not args.no_ip_per_container:
+            for port in task['ports']:
+                yield('{}_{}_{}'.format(prefix, task_ip.replace('.', '_'),
+                                        port))
+        else:
+            for port in task['ports']:
+                yield('{}_{}'.format(prefix, port))
 
 
-def get_svnames_from_tasks(tasks):
+def get_svnames_from_tasks(args, tasks):
     svnames = []
     for task in tasks:
-        svnames += get_svnames_from_task(task)
+        svnames += get_svnames_from_task(args, task)
     return svnames
 
 
@@ -227,11 +232,11 @@ def _has_pending_requests(listener):
     return int(listener.qcur or 0) > 0 or int(listener.scur or 0) > 0
 
 
-def find_drained_task_ids(app, listeners, haproxy_count):
+def find_drained_task_ids(args, app, listeners, haproxy_count):
     """Return app tasks which have all haproxy listeners down and draining
        of any pending sessions or connections
     """
-    tasks = zip(get_svnames_from_tasks(app['tasks']), app['tasks'])
+    tasks = zip(get_svnames_from_tasks(args, app['tasks']), app['tasks'])
     drained_listeners = select_drained_listeners(listeners)
 
     drained_task_ids = []
@@ -246,7 +251,7 @@ def find_drained_task_ids(app, listeners, haproxy_count):
 def find_draining_task_ids(app, listeners, haproxy_count):
     """Return app tasks which have all haproxy listeners draining
     """
-    tasks = zip(get_svnames_from_tasks(app['tasks']), app['tasks'])
+    tasks = zip(get_svnames_from_tasks(args, app['tasks']), app['tasks'])
     draining_listeners = select_draining_listeners(listeners)
 
     draining_task_ids = []
@@ -296,12 +301,12 @@ def find_tasks_to_kill(args, new_app, old_app, timestamp):
         if waiting_for_drained_listeners(listeners):
             continue
 
-        return find_drained_task_ids(old_app, listeners, haproxy_count)
+        return find_drained_task_ids(args, old_app, listeners, haproxy_count)
 
     logger.info('Timed out waiting for tasks to fully drain, find any draining'
                 ' tasks and continue with deployment...')
 
-    return find_draining_task_ids(old_app, listeners, haproxy_count)
+    return find_draining_task_ids(args, old_app, listeners, haproxy_count)
 
 
 def deployment_in_progress(app):
@@ -435,7 +440,7 @@ def get_service_port(app):
 def set_service_port(app, servicePort):
     try:
         app['container']['docker']['portMappings'][0]['servicePort'] = \
-          int(servicePort)
+            int(servicePort)
     except KeyError:
         app['ports'][0] = int(servicePort)
 
@@ -470,7 +475,7 @@ def set_service_ports(app, servicePort):
     app['labels']['HAPROXY_0_PORT'] = str(get_service_port(app))
     try:
         app['container']['docker']['portMappings'][0]['servicePort'] = \
-          int(servicePort)
+            int(servicePort)
         return app
     except KeyError:
         app['ports'][0] = int(servicePort)
@@ -623,6 +628,13 @@ def get_arg_parser():
                         help="Initial number of app instances to launch",
                         type=int, default=1
                         )
+    parser.add_argument("--no-ip-per-container", "-n",
+                        help="Set this to False if marathon lb is "
+                        "generating listener/backend names in the form of "
+                        "'mesos_slave_ip_container_ip_port', set this to true "
+                        "if marathon lb is generating listener/backend names "
+                        "in the form 'mesos_slave_ip_port'",
+                        default=False, action="store_true")
     parser.add_argument("--resume", "-r",
                         help="Resume from a previous deployment",
                         action="store_true"


### PR DESCRIPTION
Changed zdd script to have a option to specify whether ip per container is being used, currently it assumes svnames generated by marathon-lb to be of the form [mesos_slave_ip_container_ip_port](https://github.com/mesosphere/marathon-lb/blob/master/zdd.py#L216) in certain cases, which is not true, marathon-lb is generating svnames in the form of [mesos_slave_ip_port](https://github.com/mesosphere/marathon-lb/blob/master/marathon_lb.py#L1127), so adding a flag which when set to True works with the svnames generated by marathon-lb currently.

Example: 

If mesos slave ip is 10.0.6.25 and container ip is 172.17.1.71 and host port is 31184, zdd was assuming haproxy generated a svname of the form:
**10_0_6_25_172_17_1_71_31184**

But marathon-lb is generating svname if the form **10_0_6_25_31184** in the add_backend [function call](https://github.com/mesosphere/marathon-lb/blob/master/marathon_lb.py#L1127), where it just adds task['host'] as service name. But zdd was adding [**task['host']_task['ip']_port**](https://github.com/mesosphere/marathon-lb/blob/master/zdd.py#L216) , which is not reflected in marathon-lb. 

So zdd was going into infinite loop when haproxy generates svname without container ip with the following output being printed infintely. 
**zdd: Existing app running 5 instances, new app running 5 instances
zdd: Found 10 app listeners across 1 HAProxy instances**

Added a flag --no-ip-per-container , which tells zdd that the haproxy svnames doesn't include container ip and just includes host ip. This will prevent it from going into infinite loop mentioned above. This flag by default is set to False , so that it doesn't break existing functionality.