### PR TITLE
populated listeners in zdd to prevent infinite loop

### DIFF
--- a/zdd.py
+++ b/zdd.py
@@ -258,7 +258,6 @@ def max_wait_not_exceeded(max_wait, timestamp):
 def find_tasks_to_kill(args, new_app, old_app, timestamp):
     marathon_lb_urls = get_marathon_lb_urls(args)
     haproxy_count = len(marathon_lb_urls)
-    listeners = []
     listeners = fetch_app_listeners(new_app, marathon_lb_urls)
     while max_wait_not_exceeded(args.max_wait, timestamp):
         time.sleep(args.step_delay)

--- a/zdd.py
+++ b/zdd.py
@@ -259,7 +259,7 @@ def find_tasks_to_kill(args, new_app, old_app, timestamp):
     marathon_lb_urls = get_marathon_lb_urls(args)
     haproxy_count = len(marathon_lb_urls)
     listeners = []
-
+    listeners = fetch_app_listeners(new_app, marathon_lb_urls)
     while max_wait_not_exceeded(args.max_wait, timestamp):
         time.sleep(args.step_delay)
 


### PR DESCRIPTION
- The continue statement in [find_tasks_to_kill](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L271) doesn't allow [listeners](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L274) to be populated, as long as [haproxy pids](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L124) length is > 1.

- This causes the script to go into infinite loop whenever [max wait exceeds](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L263) and length of haproxy_pids continue to remain greater than 1. It doesn't force kill the old_apps after max wait as empty listeners is passed to [find_draining_task_ids](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L297), which will return back a [empty list](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L245) when listener is empty. 

- This causes [find_tasks_to_kill](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L322) to return empty list, thus [this](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L327) if condition fails, leading to swap_zdd_apps calling itself [recursively](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L345) , ending up in infinite loop.

Hence the PR, tries to prevent this by populating listeners list before even it reaches the [continue](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L271) statement, so when [max_wait_time](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L263) exceeds , this populated list is passed to [find_draining_task_ids](https://github.com/mesosphere/marathon-lb/blob/e55903e436c4ead8f6d02497e69e904d5bf88ba7/zdd.py#L297) which can then force kill them, preventing the infinite loop.