### PR TITLE
Haproxy map support to speed up vhost to backend lookup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $ ./marathon_lb.py --marathon http://localhost:8080 --group external --skip-vali
 ```
 
 ### Using Haproxy maps for backend lookup.
-You can use haproxy maps to speed up web application (vhosts) to backend lookup. This can be very useful for large installations where vhost to backend lookup can take considerable time. This can be done by using --haproxy-map flag.
+You can use haproxy maps to speed up web application (vhosts) to backend lookup. This is very useful for large installations where the traditional vhost to backend rules comparison takes considerable time since it sequentially compares each rule. Haproxy map creates a hash based lookup table so its fast compared to the other approach, this is supported in marathon-lb using --haproxy-map flag.
 
 ```console 
 $ ./marathon_lb.py --marathon http://localhost:8080 --group external --haproxy-map

--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ You can skip the configuration file validation (via calling HAProxy service) pro
 $ ./marathon_lb.py --marathon http://localhost:8080 --group external --skip-validation
 ```
 
+### Using Haproxy maps for backends.
+You can use haproxy maps to map web application to backends to speed up this lookup. This can be very useful for large installations where web application to backend lookup can take considerable time.This can be done by using --haproxy-map flag.
+
+```console 
+$ ./marathon_lb.py --marathon http://localhost:8080 --group external --haproxy-map
+```
+Currently it creates a lookup dictionary only for host headers(both http and https), for path based routing and auth, it uses the usual backend rules.
+
 ### API endpoints
 
 Marathon-lb exposes a few endpoints on port 9090 (by default). They are:

--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ $ ./marathon_lb.py --marathon http://localhost:8080 --group external --skip-vali
 ```
 
 ### Using Haproxy maps for backend lookup.
-You can use haproxy maps to speed up web application (vhosts) to backend lookup. This can be very useful for large installations where vhost to backend lookup can take considerable time.This can be done by using --haproxy-map flag.
+You can use haproxy maps to speed up web application (vhosts) to backend lookup. This can be very useful for large installations where vhost to backend lookup can take considerable time. This can be done by using --haproxy-map flag.
 
 ```console 
 $ ./marathon_lb.py --marathon http://localhost:8080 --group external --haproxy-map
 ```
-Currently it creates a lookup dictionary only for host header(both http and https) and x-marathon-app-id header.But for path based routing and auth, it uses the usual backend rules comparison.
+Currently it creates a lookup dictionary only for host header(both http and https) and x-marathon-app-id header. But for path based routing and auth, it uses the usual backend rules comparison.
 
 ### API endpoints
 

--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ You can skip the configuration file validation (via calling HAProxy service) pro
 $ ./marathon_lb.py --marathon http://localhost:8080 --group external --skip-validation
 ```
 
-### Using Haproxy maps for backends.
-You can use haproxy maps to map web application to backends to speed up this lookup. This can be very useful for large installations where web application to backend lookup can take considerable time.This can be done by using --haproxy-map flag.
+### Using Haproxy maps for backend lookup.
+You can use haproxy maps to speed up web application (vhosts) to backend lookup. This can be very useful for large installations where vhost to backend lookup can take considerable time.This can be done by using --haproxy-map flag.
 
 ```console 
 $ ./marathon_lb.py --marathon http://localhost:8080 --group external --haproxy-map
 ```
-Currently it creates a lookup dictionary only for host headers(both http and https), for path based routing and auth, it uses the usual backend rules.
+Currently it creates a lookup dictionary only for host header(both http and https) and x-marathon-app-id header.But for path based routing and auth, it uses the usual backend rules comparison.
 
 ### API endpoints
 

--- a/config.py
+++ b/config.py
@@ -223,6 +223,17 @@ of the `HAPROXY_HTTP_FRONTEND_HEAD`
 '''))
 
         self.add_template(
+            ConfigTemplate(name='MAP_HTTP_FRONTEND_ACL',
+                           value='''\
+  use_backend %[req.hdr(host),lower,map_dom({haproxy_dir}/domain2backend.map)]
+''',
+                           overridable=True,
+                           description='''\
+The ACL that glues a backend to the corresponding virtual host
+of the `HAPROXY_HTTP_FRONTEND_HEAD` using haproxy maps.
+'''))
+
+        self.add_template(
             ConfigTemplate(name='HTTP_FRONTEND_ACL_WITH_AUTH',
                            value='''\
   acl host_{cleanedUpHostname} hdr(host) -i {hostname}
@@ -248,6 +259,17 @@ Define the ACL matching a particular hostname, but unlike
 `HAPROXY_HTTP_FRONTEND_ACL`, only do the ACL portion. Does not glue
 the ACL to the backend. This is useful only in the case of multiple
 vhosts routing to the same backend.
+'''))
+
+        self.add_template(
+            ConfigTemplate(name='MAP_HTTP_FRONTEND_ACL_ONLY',
+                           value='''\
+  use_backend %[req.hdr(host),lower,map_dom({haproxy_dir}/domain2backend.map)]
+''',
+                           overridable=True,
+                           description='''\
+Define the ACL matching a particular hostname, This is useful only in the case
+ of multiple vhosts routing to the same backend in haproxy map.
 '''))
 
         self.add_template(
@@ -392,6 +414,18 @@ of the `HAPROXY_HTTP_FRONTEND_APPID_HEAD`.
 '''))
 
         self.add_template(
+            ConfigTemplate(name='MAP_HTTP_FRONTEND_APPID_ACL',
+                           value='''\
+  use_backend %[req.hdr(x-marathon-app-id),lower,\
+map_str({haproxy_dir}/domain2backend.map)]
+''',
+                           overridable=True,
+                           description='''\
+The ACL that glues a backend to the corresponding app
+of the `HAPROXY_HTTP_FRONTEND_APPID_HEAD` using haproxy maps.
+'''))
+
+        self.add_template(
             ConfigTemplate(name='HTTPS_FRONTEND_ACL',
                            value='''\
   use_backend {backend} if {{ ssl_fc_sni {hostname} }}
@@ -400,6 +434,17 @@ of the `HAPROXY_HTTP_FRONTEND_APPID_HEAD`.
                            description='''\
 The ACL that performs the SNI based hostname matching
 for the `HAPROXY_HTTPS_FRONTEND_HEAD` template.
+'''))
+
+        self.add_template(
+            ConfigTemplate(name='MAP_HTTPS_FRONTEND_ACL',
+                           value='''\
+  use_backend %[ssl_fc_sni,lower,map_dom({haproxy_dir}/domain2backend.map)]
+''',
+                           overridable=True,
+                           description='''\
+The ACL that performs the SNI based hostname matching
+for the `HAPROXY_HTTPS_FRONTEND_HEAD` template using haproxy maps
 '''))
 
         self.add_template(
@@ -874,10 +919,20 @@ Specified as {specifiedAs}.
             return app.labels['HAPROXY_{0}_HTTP_FRONTEND_ACL']
         return self.t['HTTP_FRONTEND_ACL'].value
 
+    def haproxy_map_http_frontend_acl(self, app):
+        if 'HAPROXY_{0}_HTTP_FRONTEND_ACL' in app.labels:
+            return app.labels['HAPROXY_{0}_HTTP_FRONTEND_ACL']
+        return self.t['MAP_HTTP_FRONTEND_ACL'].value
+
     def haproxy_http_frontend_acl_only(self, app):
         if 'HAPROXY_{0}_HTTP_FRONTEND_ACL_ONLY' in app.labels:
             return app.labels['HAPROXY_{0}_HTTP_FRONTEND_ACL_ONLY']
         return self.t['HTTP_FRONTEND_ACL_ONLY'].value
+
+    def haproxy_map_http_frontend_acl_only(self, app):
+        if 'HAPROXY_{0}_HTTP_FRONTEND_ACL_ONLY' in app.labels:
+            return app.labels['HAPROXY_{0}_HTTP_FRONTEND_ACL_ONLY']
+        return self.t['MAP_HTTP_FRONTEND_ACL_ONLY'].value
 
     def haproxy_http_frontend_routing_only(self, app):
         if 'HAPROXY_{0}_HTTP_FRONTEND_ROUTING_ONLY' in app.labels:
@@ -933,10 +988,20 @@ Specified as {specifiedAs}.
             return app.labels['HAPROXY_{0}_HTTP_FRONTEND_APPID_ACL']
         return self.t['HTTP_FRONTEND_APPID_ACL'].value
 
+    def haproxy_map_http_frontend_appid_acl(self, app):
+        if 'HAPROXY_{0}_HTTP_FRONTEND_APPID_ACL' in app.labels:
+            return app.labels['HAPROXY_{0}_HTTP_FRONTEND_APPID_ACL']
+        return self.t['MAP_HTTP_FRONTEND_APPID_ACL'].value
+
     def haproxy_https_frontend_acl(self, app):
         if 'HAPROXY_{0}_HTTPS_FRONTEND_ACL' in app.labels:
             return app.labels['HAPROXY_{0}_HTTPS_FRONTEND_ACL']
         return self.t['HTTPS_FRONTEND_ACL'].value
+
+    def haproxy_map_https_frontend_acl(self, app):
+        if 'HAPROXY_{0}_HTTPS_FRONTEND_ACL' in app.labels:
+            return app.labels['HAPROXY_{0}_HTTPS_FRONTEND_ACL']
+        return self.t['MAP_HTTPS_FRONTEND_ACL'].value
 
     def haproxy_https_frontend_acl_with_path(self, app):
         if 'HAPROXY_{0}_HTTPS_FRONTEND_ACL_WITH_PATH' in app.labels:
@@ -1349,7 +1414,13 @@ labels.append(Label(name='BACKEND_HEAD',
 labels.append(Label(name='HTTP_FRONTEND_ACL',
                     func=set_label,
                     description=''))
+labels.append(Label(name='MAP_HTTP_FRONTEND_ACL',
+                    func=set_label,
+                    description=''))
 labels.append(Label(name='HTTP_FRONTEND_ACL_ONLY',
+                    func=set_label,
+                    description=''))
+labels.append(Label(name='MAP_HTTP_FRONTEND_ACL_ONLY',
                     func=set_label,
                     description=''))
 labels.append(Label(name='HTTP_FRONTEND_ROUTING_ONLY',
@@ -1379,7 +1450,13 @@ labels.append(Label(name='HTTP_FRONTEND_ROUTING_ONLY_WITH_PATH_AND_AUTH',
 labels.append(Label(name='HTTP_FRONTEND_APPID_ACL',
                     func=set_label,
                     description=''))
+labels.append(Label(name='MAP_HTTP_FRONTEND_APPID_ACL',
+                    func=set_label,
+                    description=''))
 labels.append(Label(name='HTTPS_FRONTEND_ACL',
+                    func=set_label,
+                    description=''))
+labels.append(Label(name='MAP_HTTPS_FRONTEND_ACL',
                     func=set_label,
                     description=''))
 labels.append(Label(name='HTTPS_FRONTEND_ACL_WITH_AUTH',


### PR DESCRIPTION
Currently vhost to backend lookup happens in the traditional way, where each rule is scanned to lookup the corresponding backend, this can add considerable latency when the number of apps/vhosts are large in number (especially for apps/vhosts which appear at the rear end of the rules comparison).

Ex:

frontend xyz
   {other_lines}
   use_backend backend1 if { hdr(Host) -i myapp.domain1.com }
   use_backend backend2 if { hdr(Host) -i myapp.domain2.com }
   ....
   ....
   ....
   use_backend backendN if { hdr(Host) -i myapp.domainN.com }

Here the lookups for domainN, N-1, N-2 etc . can take considerable time, since these comparisons are sequential. Hence this PR supports a `--haproxy-map` , which creates a lookup map which is supported by haproxy, so for the above example when we use haproxy-map, we get

frontend xyz
  {other_lines}
  use_backend %[req.hdr(host),lower,map_dom(/path/to/map)]

and /path/to/map contains:

myapp.domain1.com backend1
myapp.domain2.com backend2
...
...
...
myapp.domainN.com backendN,

which is a hash based lookup dict, this way domainN, N-1 , N-2 etc, lookups will be faster.

Currently it just works for host header and x-marathon-app-id header, it retains the rule based comparison for bath based routing and auth. 
