### PR TITLE
Set a socket connect/read timeout for SSE mode.

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -221,7 +221,7 @@ class Marathon(object):
                 params={'callbackUrl': callbackUrl})
 
     def get_event_stream(self):
-        url = self.host+"/v2/events"
+        url = self.host + "/v2/events"
         logger.info(
             "SSE Active, trying fetch events from {0}".format(url))
 
@@ -230,8 +230,11 @@ class Marathon(object):
             'Accept': 'text/event-stream'
         }
 
-        resp = requests.get(url, stream=True,
-                            headers=headers, auth=self.__auth)
+        resp = requests.get(url,
+                            stream=True,
+                            headers=headers,
+                            timeout=(3.05, 46),
+                            auth=self.__auth)
 
         class Event(object):
             def __init__(self, data):


### PR DESCRIPTION
By default, we do not set a connect/read timeout on sockets when in SSE
mode. It's possible that the TCP socket may actually be stale
(somehow?), so we'll set a timeout on the socket. By default, we depend
on the platform setting.

This will hopefully address issues #230, #234, and #238.