### PR TITLE
Over-ride initial instances when it is greater than deployment target instances to prevent infinite loop in zdd.

### DIFF
--- a/zdd.py
+++ b/zdd.py
@@ -513,10 +513,13 @@ def prepare_deploy(args, previous_deploys, app):
     if len(previous_deploys) > 0:
         last_deploy = select_last_deploy(previous_deploys)
 
-        app['instances'] = args.initial_instances
         next_colour = select_next_colour(last_deploy)
         next_port = select_next_port(last_deploy)
         deployment_target_instances = last_deploy['instances']
+        if args.initial_instances > deployment_target_instances:
+            app['instances'] = deployment_target_instances
+        else:
+            app['instances'] = args.initial_instances
     else:
         next_colour = 'blue'
         next_port = get_service_port(app)
@@ -612,7 +615,10 @@ def get_arg_parser():
                         type=int, default=5
                         )
     parser.add_argument("--initial-instances", "-i",
-                        help="Initial number of app instances to launch",
+                        help="Initial number of app instances to launch."
+                        " If this number is greater than total number of"
+                        " existing instances, then this will be overridden"
+                        " by the latter number",
                         type=int, default=1
                         )
     parser.add_argument("--resume", "-r",


### PR DESCRIPTION
Currently when `args.initial_instances` is greater than `deployment_target_instances`(`HAPROXY_DEPLOYMENT_TARGET_INSTANCES`), zdd script goes into infinite loop.

It sets `app['instances'] = args.initial_instances` [here](https://github.com/mesosphere/marathon-lb/blob/f9cb0426e4401c1e725596b37f0fe9c02d627e04/zdd.py#L516) as a part of [prepare_deploy](https://github.com/mesosphere/marathon-lb/blob/f9cb0426e4401c1e725596b37f0fe9c02d627e04/zdd.py#L560) function call. And then the control flows to [swap_zdd_apps](https://github.com/mesosphere/marathon-lb/blob/f9cb0426e4401c1e725596b37f0fe9c02d627e04/zdd.py#L578),  and only way to return from this recursive function is when [ready_to_delete_old_app](https://github.com/mesosphere/marathon-lb/blob/f9cb0426e4401c1e725596b37f0fe9c02d627e04/zdd.py#L323) is true(  the other way is when it enters [this](https://github.com/mesosphere/marathon-lb/blob/f9cb0426e4401c1e725596b37f0fe9c02d627e04/zdd.py#L326) if  statement, which it will never enter when all old tasks are killed). But [ready_to_delete_old_app](https://github.com/mesosphere/marathon-lb/blob/f9cb0426e4401c1e725596b37f0fe9c02d627e04/zdd.py#L347) will never return true as [new_app['instances'] is > deployment target](https://github.com/mesosphere/marathon-lb/blob/f9cb0426e4401c1e725596b37f0fe9c02d627e04/zdd.py#L348). So this results in infinite loop in swap_zdd_apps. 

So in this PR initial_instances(`app['instances']` for new app) will be overridden by `deployment_target_instances` when  former is greater than later. Have updated `help` for the same.