### PR TITLE
changed haproxy maps to use map(map_str) instead of map_dom, as map_dom does a substring matching which can have undesired effects, whereas map is a strict string matching

### DIFF
--- a/config.py
+++ b/config.py
@@ -228,7 +228,8 @@ of the `HAPROXY_HTTP_FRONTEND_HEAD`
         self.add_template(
             ConfigTemplate(name='MAP_HTTP_FRONTEND_ACL',
                            value='''\
-  use_backend %[req.hdr(host),lower,map({haproxy_dir}/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,regsub(:.*$,,),\
+map({haproxy_dir}/domain2backend.map)]
 ''',
                            overridable=True,
                            description='''\
@@ -267,7 +268,8 @@ vhosts routing to the same backend.
         self.add_template(
             ConfigTemplate(name='MAP_HTTP_FRONTEND_ACL_ONLY',
                            value='''\
-  use_backend %[req.hdr(host),lower,map({haproxy_dir}/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,regsub(:.*$,,),\
+map({haproxy_dir}/domain2backend.map)]
 ''',
                            overridable=True,
                            description='''\

--- a/config.py
+++ b/config.py
@@ -228,7 +228,7 @@ of the `HAPROXY_HTTP_FRONTEND_HEAD`
         self.add_template(
             ConfigTemplate(name='MAP_HTTP_FRONTEND_ACL',
                            value='''\
-  use_backend %[req.hdr(host),lower,map_dom({haproxy_dir}/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,map({haproxy_dir}/domain2backend.map)]
 ''',
                            overridable=True,
                            description='''\
@@ -267,7 +267,7 @@ vhosts routing to the same backend.
         self.add_template(
             ConfigTemplate(name='MAP_HTTP_FRONTEND_ACL_ONLY',
                            value='''\
-  use_backend %[req.hdr(host),lower,map_dom({haproxy_dir}/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,map({haproxy_dir}/domain2backend.map)]
 ''',
                            overridable=True,
                            description='''\
@@ -420,7 +420,7 @@ of the `HAPROXY_HTTP_FRONTEND_APPID_HEAD`.
             ConfigTemplate(name='MAP_HTTP_FRONTEND_APPID_ACL',
                            value='''\
   use_backend %[req.hdr(x-marathon-app-id),lower,\
-map_str({haproxy_dir}/domain2backend.map)]
+map({haproxy_dir}/domain2backend.map)]
 ''',
                            overridable=True,
                            description='''\
@@ -442,7 +442,7 @@ for the `HAPROXY_HTTPS_FRONTEND_HEAD` template.
         self.add_template(
             ConfigTemplate(name='MAP_HTTPS_FRONTEND_ACL',
                            value='''\
-  use_backend %[ssl_fc_sni,lower,map_dom({haproxy_dir}/domain2backend.map)]
+  use_backend %[ssl_fc_sni,lower,map({haproxy_dir}/domain2backend.map)]
 ''',
                            overridable=True,
                            description='''\

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -1867,18 +1867,18 @@ backend nginx3_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091
   mode http
   use_backend %[req.hdr(x-marathon-app-id),lower,\
-map_str(/etc/haproxy/domain2backend.map)]
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_https_in
   bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
   mode http
-  use_backend %[ssl_fc_sni,lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[ssl_fc_sni,lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend apache_10001
   bind *:10001
@@ -1965,13 +1965,13 @@ frontend marathon_http_in
   acl host_server_apache_net_apache hdr(host) -i server.apache.net
   acl path_apache_10001 path_beg /apache
   use_backend apache_10001 if host_server_apache_net_apache path_apache_10001
-  use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091
   mode http
   use_backend %[req.hdr(x-marathon-app-id),lower,\
-map_str(/etc/haproxy/domain2backend.map)]
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_https_in
   bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
@@ -1979,7 +1979,7 @@ frontend marathon_https_in
   acl path_apache_10001 path_beg /apache
   use_backend apache_10001 if { ssl_fc_sni server.apache.net } \
 path_apache_10001
-  use_backend %[ssl_fc_sni,lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[ssl_fc_sni,lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend apache_10001
   bind *:10001
@@ -2066,13 +2066,13 @@ frontend marathon_http_in
   acl host_server_apache_net_apache hdr(host) -i server.apache.net
   acl host_server_apache_net_apache hdr(host) -i server.apache1.net
   use_backend apache_10001 if host_server_apache_net_apache path_apache_10001
-  use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091
   mode http
   use_backend %[req.hdr(x-marathon-app-id),lower,\
-map_str(/etc/haproxy/domain2backend.map)]
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_https_in
   bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
@@ -2082,7 +2082,7 @@ frontend marathon_https_in
 path_apache_10001
   use_backend apache_10001 if { ssl_fc_sni server.apache1.net } \
 path_apache_10001
-  use_backend %[ssl_fc_sni,lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[ssl_fc_sni,lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend apache_10001
   bind *:10001
@@ -2168,18 +2168,18 @@ frontend marathon_http_in
   acl host_server_apache_net_apache hdr(host) -i server.apache.net
   acl host_server_apache_net_apache hdr(host) -i server.apache1.net
   redirect scheme https code 301 if !{ ssl_fc } host_server_apache_net_apache
-  use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091
   mode http
   use_backend %[req.hdr(x-marathon-app-id),lower,\
-map_str(/etc/haproxy/domain2backend.map)]
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_https_in
   bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
   mode http
-  use_backend %[ssl_fc_sni,lower,map_dom(/etc/haproxy/domain2backend.map)]
+  use_backend %[ssl_fc_sni,lower,map(/etc/haproxy/domain2backend.map)]
 
 frontend apache_10001
   bind *:10001

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -1867,7 +1867,8 @@ backend nginx3_10000
 frontend marathon_http_in
   bind *:80
   mode http
-  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,regsub(:.*$,,),\
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -1965,7 +1966,8 @@ frontend marathon_http_in
   acl host_server_apache_net_apache hdr(host) -i server.apache.net
   acl path_apache_10001 path_beg /apache
   use_backend apache_10001 if host_server_apache_net_apache path_apache_10001
-  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,regsub(:.*$,,),\
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -2066,7 +2068,8 @@ frontend marathon_http_in
   acl host_server_apache_net_apache hdr(host) -i server.apache.net
   acl host_server_apache_net_apache hdr(host) -i server.apache1.net
   use_backend apache_10001 if host_server_apache_net_apache path_apache_10001
-  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,regsub(:.*$,,),\
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091
@@ -2168,7 +2171,8 @@ frontend marathon_http_in
   acl host_server_apache_net_apache hdr(host) -i server.apache.net
   acl host_server_apache_net_apache hdr(host) -i server.apache1.net
   redirect scheme https code 301 if !{ ssl_fc } host_server_apache_net_apache
-  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domain2backend.map)]
+  use_backend %[req.hdr(host),lower,regsub(:.*$,,),\
+map(/etc/haproxy/domain2backend.map)]
 
 frontend marathon_http_appid_in
   bind *:9091


### PR DESCRIPTION
Currently we are using same map file for hashing both X-Marathon-App-ID and hdr(host), so if we end up with a map as shown below 

```
app1.stg.corp.mydom.com mybackend1
/app1 mybackend1
app1.adm.stg.corp.mydom.com mybackend2
/app1adm mybackend2
```

where  app ids are `/app1` and `/app1adm`(These are X-Marathon-App-IDs) and vhosts as `app1.stg.corp.mydom.com` and `app1.adm.stg.corp.mydom.com`, if we use map_dom , it spilts up the domain on dots(.) and does a substring comparison of the tokens and returns the first match, so if we access `http://app1.adm.stg.corp.mydom.com`, it splits host(hdr) up based on tokens and the first match for the tokens will be `/app1`, so the request ends up going to `mybackend1` , instead of `mybackend2`.

Infact `map_dom` apart from matching `app1.adm.stg.corp.mydom.com` will match any of `/app1`, `/adm`, `/stg`, `/corp`, `/mydom`, `/com`, `/app1.adm`, `/app1.adm.stg`, `/app1.adm.stg.corp` `/app1.adm.stg.corp.mydom`, `corp.mydom.com`, `mydom.com`, `stg.corp.mydom.com`, `adm.stg.corp.mydom.com` and so on , whichever among these is the first match, it returns that backend.

So this PR changes `map_dom` to `map`(equivalent to map_str), which does a exact string match.
One functionality which we will be losing with this change is, earlier if we had a vhost entry for `test.com`, HAProxy routing would work for both `test.com` as well as `www.test.com`, but now since it is a strict string match, we need to have 2 vhosts entry one for `test.com` and another for `www.test.com`, so we will be handling only the vhosts which are explicitly defined. 

Also map_dom used to match `domain`, ignoring the `port number` from the request  header(this ensures we dont have to specify port number in the map along with vhost), to enable this feature without map_dom , have used a regex `regsub(:.*$,,)` which removes the port number (if it exists) from the host header before doing a string match with map.