### PR TITLE
Blue green hybrid deployment with zdd

### DIFF
--- a/Longhelp.md
+++ b/Longhelp.md
@@ -1017,6 +1017,20 @@ The target number of app instances to seek during deployment. You
 generally do not need to modify this unless you implement your
 own deployment orchestrator.
                     
+## `HAPROXY_DEPLOYMENT_NEW_INSTANCES`
+  *per app*
+
+Specified as `HAPROXY_DEPLOYMENT_NEW_INSTANCES`.
+
+The number of instances to be created in new group while doing 
+blue-green deployments. You generally do not need to modify this
+unless you implement your own blue green deployment orchestrator.
+
+Ex: In zdd , if `haproxy_deployment_target_instances` is 10 and current
+deployment color is `blue`,  if you run zdd with `--new-instances` as 2,
+there will be 2 instances created in `green` group and 2 deleted from `blue`.
+So it will be blue:green with 80:20 ratio.
+
 
 ## `HAPROXY_{n}_GROUP`
   *per service port*
@@ -1149,6 +1163,3 @@ evaluated in the order it appears in the configuration.
 Ex: `HAPROXY_0_VHOST = 'marathon.mesosphere.com'`
 
 Ex: `HAPROXY_0_VHOST = 'marathon.mesosphere.com,marathon'`
-                    
-
-

--- a/README.md
+++ b/README.md
@@ -290,6 +290,35 @@ Zero downtime deployments are accomplished through the use of a Lua module, whic
 
 The ZDD script includes the ability to specify a pre-kill hook, which is executed before draining tasks are terminated. This allows you to run your own automated checks against the old and new app before the deploy continues.
 
+
+## Traffic splitting between Blue and Green Apps.
+
+
+Zdd has support to split the traffic between two versions of same app(Version blue and Version green) by having instances of both versions live at the same time. This is supported with the help of `HAPROXY_DEPLOYMENT_NEW_INSTANCES` label.
+
+When you run zdd with `--new-instances` flag , it creates only the specified number of instances in new app, and deletes the same number of instances from old app (instead of the normal, create all instances in new and delete all from old approach), to ensure that the number of instances in new app and old app together is equal to `HAPROXY_DEPLOYMENT_TARGET_INSTANCES`.
+
+Example : Consider the same nginx app example where there are 10 instances of nginx running image version V1, now we can use zdd to create 2 instances of version V2, and retain 8 instances of V1 so that traffic is split in ratio 80:20 (old:new).
+
+Creating 2 instances with new version automatically deletes 2 instances in existing version.You could do this using the following command:
+
+```
+./zdd.py -j 1-nginx.json -m http://master.mesos:8080 -f -l http://marathon-lb.marathon.mesos:9090 --syslog-socket /dev/null --new-instances 2
+```
+This state where you have instances of both old and new versions of same app live at the same time is called hybrid state.
+
+When a deployment group is in hybrid state, it needs to be converted into completely current version or completely previous version before deploying any further versions, this could be done with the help of `--complete-cur` and `--complete-prev` flags in zdd.
+
+When you run the below command to convert all instances to new version so that traffic split ratio becomes 0:100 (old:new) and it deletes the old app. This is graceful as it follows usual zdd procedure of waiting for tasks/instances to drain before deleting them.
+
+```
+./zdd.py -j 1-nginx.json -m http://master.mesos:8080 -f -l http://marathon-lb.marathon.mesos:9090 --syslog-socket /dev/null --complete-cur
+```
+Similarly you can use `--complete-prev` flag to convert all instances to old version (This is essentially a rollback) so that traffic split ratio becomes 100:0 (old:new) and it deletes the new app.
+
+Currently only one hop of traffic split is supported, so you can specify the number of new instances (directly proportional to traffic split ratio) only when app is having all instances of same version(completely blue or completely green). This implies `--new-instances` flag cannot be specified in hybrid mode to change traffic split ratio (instance ratio) as updating marathon label (`HAPROXY_DEPLOYMENT_NEW_INSTANCES`) currently triggers new deployment in marathon which will not be graceful. Once marathon supports dynamic labels we can have multiple hops of traffic split ratio. Currently for the example mentioned, the traffic split ratio is 100:0--->`80:20`--->0:100 , where there is only one hop when both versions get traffic simultaneously.
+
+
 ## Mesos with IP-per-task support
 
 Marathon-lb supports load balancing for applications that use the Mesos IP-per-task

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1154,6 +1154,17 @@ def get_apps(marathon):
                 new = prev
                 old = cur
 
+            if 'HAPROXY_DEPLOYMENT_NEW_INSTANCES' in new['labels']:
+                if int(new['labels']['HAPROXY_DEPLOYMENT_NEW_INSTANCES'] != 0):
+                    new_scale_time = dateutil.parser.parse(
+                        new['versionInfo']['lastScalingAt'])
+                    old_scale_time = dateutil.parser.parse(
+                        old['versionInfo']['lastScalingAt'])
+                    if old_scale_time > new_scale_time:
+                        temp = old
+                        old = new
+                        new = temp
+
             target_instances = \
                 int(new['labels']['HAPROXY_DEPLOYMENT_TARGET_INSTANCES'])
 

--- a/tests/test_zdd.py
+++ b/tests/test_zdd.py
@@ -2,7 +2,6 @@ import unittest
 import zdd
 import mock
 import json
-import time
 
 
 class Arguments:
@@ -15,6 +14,9 @@ class Arguments:
     marathon_auth_credential_file = None
     auth_credentials = None
     pre_kill_hook = None
+    new_instances = 0
+    complete_cur = False
+    complete_prev = False
 
 
 class MyResponse:
@@ -53,7 +55,7 @@ class TestBluegreenDeploy(unittest.TestCase):
         args.initial_instances = 5
         zdd.scale_new_app_instances(args, new_app, old_app)
         mock.assert_called_with(
-          args, new_app, 15)
+            args, new_app, 15)
 
     @mock.patch('zdd.scale_marathon_app_instances')
     def test_scale_new_app_instances_to_target(self, mock):
@@ -72,7 +74,27 @@ class TestBluegreenDeploy(unittest.TestCase):
         args.initial_instances = 5
         zdd.scale_new_app_instances(args, new_app, old_app)
         mock.assert_called_with(
-          args, new_app, 30)
+            args, new_app, 30)
+
+    @mock.patch('zdd.scale_marathon_app_instances')
+    def test_scale_new_app_instances_hybrid(self, mock):
+        """When scaling new instances up, if we have met or surpassed the
+           amount of instances deployed for old_app, go right to our
+           deployment target amount of instances for new_app
+        """
+        new_app = {
+            'instances': 10,
+            'labels': {
+                'HAPROXY_DEPLOYMENT_NEW_INSTANCES': 15,
+                'HAPROXY_DEPLOYMENT_TARGET_INSTANCES': 30
+            }
+        }
+        old_app = {'instances': 20}
+        args = Arguments()
+        args.initial_instances = 5
+        zdd.scale_new_app_instances(args, new_app, old_app)
+        mock.assert_called_with(
+            args, new_app, 15)
 
     def test_find_drained_task_ids(self):
         listeners = _load_listeners()
@@ -224,6 +246,7 @@ class TestBluegreenDeploy(unittest.TestCase):
     "HAPROXY_DEPLOYMENT_ALT_PORT": "10001",
     "HAPROXY_DEPLOYMENT_COLOUR": "blue",
     "HAPROXY_DEPLOYMENT_GROUP": "nginx",
+    "HAPROXY_DEPLOYMENT_NEW_INSTANCES": "0",
     "HAPROXY_DEPLOYMENT_STARTED_AT": "2016-02-01T15:51:38.184623",
     "HAPROXY_DEPLOYMENT_TARGET_INSTANCES": "3",
     "HAPROXY_GROUP": "external"
@@ -233,3 +256,80 @@ class TestBluegreenDeploy(unittest.TestCase):
 ''')
         expected['labels']['HAPROXY_DEPLOYMENT_STARTED_AT'] = ""
         self.assertEqual(output, expected)
+
+    @mock.patch('requests.get',
+                mock.Mock(side_effect=lambda k, auth:
+                          MyResponse('tests/zdd_app_blue.json')))
+    def test_hybrid(self):
+        # This test just checks the output of the program against
+        # some expected output
+        from six import StringIO
+
+        out = StringIO()
+        args = Arguments()
+        args.new_instances = 1
+        zdd.do_zdd(args, out)
+        output = json.loads(out.getvalue())
+        output['labels']['HAPROXY_DEPLOYMENT_STARTED_AT'] = ""
+
+        expected = json.loads('''{
+  "acceptedResourceRoles": [
+    "*",
+    "slave_public"
+  ],
+  "container": {
+    "docker": {
+      "forcePullImage": true,
+      "image": "brndnmtthws/nginx-echo-sleep",
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 0,
+          "servicePort": 10001
+        }
+      ]
+    },
+    "type": "DOCKER"
+  },
+  "cpus": 0.1,
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 15,
+      "intervalSeconds": 3,
+      "maxConsecutiveFailures": 10,
+      "path": "/",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 15
+    }
+  ],
+  "id": "/nginx-blue",
+  "instances": 1,
+  "labels": {
+    "HAPROXY_0_PORT": "10000",
+    "HAPROXY_APP_ID": "nginx",
+    "HAPROXY_DEPLOYMENT_ALT_PORT": "10001",
+    "HAPROXY_DEPLOYMENT_COLOUR": "blue",
+    "HAPROXY_DEPLOYMENT_GROUP": "nginx",
+    "HAPROXY_DEPLOYMENT_NEW_INSTANCES": "1",
+    "HAPROXY_DEPLOYMENT_STARTED_AT": "2016-02-01T15:51:38.184623",
+    "HAPROXY_DEPLOYMENT_TARGET_INSTANCES": "3",
+    "HAPROXY_GROUP": "external"
+  },
+  "mem": 65
+}
+''')
+        expected['labels']['HAPROXY_DEPLOYMENT_STARTED_AT'] = ""
+        self.assertEqual(output, expected)
+
+    @mock.patch('requests.get',
+                mock.Mock(side_effect=lambda k, auth:
+                          MyResponse('tests/zdd_app_blue.json')))
+    def test_complete_cur_exception(self):
+        # This test just checks the output of the program against
+        # some expected output
+
+        args = Arguments()
+        args.complete_cur = True
+        self.assertRaises(Exception, zdd.do_zdd, args)


### PR DESCRIPTION
Currently zdd supports either completely blue or completely green deployments, but there are usecases when both blue and green have to be live at the same time.

Ex: Lets say current deployment color is blue with 10 instances, there is a new deployment(green color) which first needs to be deployed on 2 instances (so traffic is split 80:20) and then if nothing breaks, green can be scaled up to full capacity.

This PR supports such kind of deployments with the help of new  flag `HAPROXY_DEPLOYMENT_NEW_INSTANCES` or `--new-instances` command-line-arg to zdd.py

How it works?

- When  `--new-instances` flag is specified, it creates only the specified number of instances in new app(and deletes the same number of instance from old app). So if old app has 10 instances and zdd is run with `--new-instances` as 2, we will end up with 8 instances of old app and 2 instances of new. This state is called hybrid state.
- When deployment group is in hybrid state, the only way to do new deployment is by converting it to complete current(`--complete-cur` flag) or complete previous(rollback using `--complete-prev`) first and then deploy new app(The new app can again have `--new-instances` flag).

So the lifecycle of deployment group will be:
                                                                  
Usual Single Color deployment ---`(--new-instances)`---> Hybrid deployment --`(--complete-cur or --complete-prev)`--> Single color.

Currently You can't use `--new-instances` flag when deployment group is in `hybrid` state.(Explanation for this is below)

Currently only one hop of hybrid is supported (ratio between blue:green is based on `--new-instances` flag initially set), and after that we can convert it to completely blue or completely green, but we cannot increase/decrease the hybrid ratio. [Ex: For the above case old:new deployment ratio is 80:20, after that we can scale it to either 100:0 or 0:100, but  it cant be scaled to 60:40 or 40:60 from 80:20). Currently updating `labels` in marathon triggers a new deployment so `HAPROXY_DEPLOYMENT_NEW_INSTANCES` cannot be updated dynamically since it will cause degradation as it doesn't wait for connections to drain. Once marathon patches [this](https://github.com/mesosphere/marathon/issues/3945) issue, we can support multiple hops in hybrid.