### PR TITLE
Updated README for HAPROXY_0_VHOST usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ App labels are specified in the Marathon app definition. These can be used to ov
 }
 ```
 
+The virtual host name specified here must be in lower case.
+
 Some labels are specified _per service port_. These are denoted with the `{n}` parameter in the label key, where `{n}` corresponds to the service port index, beginning at `0`.
 
 See [the configuration doc for the full list](Longhelp.md#other-labels)


### PR DESCRIPTION
AWS ELBs use mixed case URLs and i had run into challenges when i cut and paste that into the json file. I had to troubleshoot with several haproxy configurations and identified this fix. I had also sent a comment to update the docs @ https://docs.mesosphere.com/1.7/usage/service-discovery/marathon-lb/usage/
