### PR TITLE
More clear -m help document

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1391,8 +1391,8 @@ def get_arg_parser():
                         )
     parser.add_argument("--marathon", "-m",
                         nargs="+",
-                        help="[required] Marathon endpoint, eg. -m " +
-                             "http://marathon1:8080 -m http://marathon2:8080"
+                        help="[required] Marathon endpoint, eg. " +
+                             "-m http://marathon1:8080 http://marathon2:8080"
                         )
     parser.add_argument("--listening", "-l",
                         help="(deprecated) The address this script listens " +


### PR DESCRIPTION
If you put the example like `-m http://mesos-1:8080 -m http://mesos-2:8080` can give a wrong idea that is necessary use more the one `-m` use multiples marathon instancies. But it really need to pass multiples parameters to the `-m` like `-m http://mesos-1:8080 http://mesos-2:8080`