### PR TITLE
Fix proxypass & revproxy (see #264).

### DIFF
--- a/Longhelp.md
+++ b/Longhelp.md
@@ -554,16 +554,15 @@ This option set the IPs (or IP ranges) having access to the HTTP backend.
 ```
   acl network_allowed src {network_allowed}
 ```
-## `HAPROXY_HTTP_BACKEND_PROXYPASS`
+## `HAPROXY_HTTP_BACKEND_PROXYPASS_GLUE`
   *Overridable*
 
-Specified as `HAPROXY_HTTP_BACKEND_PROXYPASS` template or with label `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS`.
+Specified as `HAPROXY_HTTP_BACKEND_PROXYPASS_GLUE` template or with label `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_GLUE`.
 
-Set the location to use for mapping local server URLs to remote servers + URL.
-Ex: HAPROXY_0_HTTP_BACKEND_PROXYPASS = '/path/to/redirect
+Backend glue for `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_PATH`.
 
 
-**Default template for `HAPROXY_HTTP_BACKEND_PROXYPASS`:**
+**Default template for `HAPROXY_HTTP_BACKEND_PROXYPASS_GLUE`:**
 ```
   http-request set-header Host {hostname}
   reqirep  "^([^ :]*)\ {proxypath}(.*)" "\1\ /\2"
@@ -583,16 +582,15 @@ Ex: HAPROXY_0_HTTP_BACKEND_REDIR = '/my/content'
   acl is_domain hdr(host) -i {hostname}
   redirect code 301 location {redirpath} if is_domain is_root
 ```
-## `HAPROXY_HTTP_BACKEND_REVPROXY`
+## `HAPROXY_HTTP_BACKEND_REVPROXY_GLUE`
   *Overridable*
 
-Specified as `HAPROXY_HTTP_BACKEND_REVPROXY` template or with label `HAPROXY_{n}_HTTP_BACKEND_REVPROXY`.
+Specified as `HAPROXY_HTTP_BACKEND_REVPROXY_GLUE` template or with label `HAPROXY_{n}_HTTP_BACKEND_REVPROXY_GLUE`.
 
-Set the URL in HTTP response headers sent from a reverse proxied server. It only updates Location, Content-Location and URL.
-Ex: HAPROXY_0_HTTP_BACKEND_REVPROXY = '/my/content'
+Backend glue for `HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH`.
 
 
-**Default template for `HAPROXY_HTTP_BACKEND_REVPROXY`:**
+**Default template for `HAPROXY_HTTP_BACKEND_REVPROXY_GLUE`:**
 ```
   acl hdr_location res.hdr(Location) -m found
   rspirep "^Location: (https?://{hostname}(:[0-9]+)?)?(/.*)" "Location:   {rootpath} if hdr_location"
@@ -1053,6 +1051,24 @@ it falls back to default `HAPROXY_GROUP` and gets associated with
 
 Load balancers with the group '*' will collect all groups.
     
+
+## `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_PATH`
+  *per service port*
+
+Specified as `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_PATH`.
+
+Set the location to use for mapping local server URLs to remote servers + URL.
+Ex: `HAPROXY_0_HTTP_BACKEND_PROXYPASS_PATH = '/path/to/redirect`
+                    
+
+## `HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH`
+  *per service port*
+
+Specified as `HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH`.
+
+Set the URL in HTTP response headers sent from a reverse proxied server. It only updates Location, Content-Location and URL.
+Ex: `HAPROXY_0_HTTP_BACKEND_REVPROXY_PATH = '/my/content'`
+                    
 
 ## `HAPROXY_{n}_MODE`
   *per service port*

--- a/config.py
+++ b/config.py
@@ -525,19 +525,18 @@ Sets HTTP headers, for example X-Forwarded-For and X-Forwarded-Proto.
 '''))
 
         self.add_template(
-            ConfigTemplate(name='HTTP_BACKEND_PROXYPASS',
+            ConfigTemplate(name='HTTP_BACKEND_PROXYPASS_GLUE',
                            value='''\
   http-request set-header Host {hostname}
   reqirep  "^([^ :]*)\ {proxypath}(.*)" "\\1\ /\\2"
 ''',
                            overridable=True,
                            description='''\
-Set the location to use for mapping local server URLs to remote servers + URL.
-Ex: HAPROXY_0_HTTP_BACKEND_PROXYPASS = '/path/to/redirect
+Backend glue for `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_PATH`.
 '''))
 
         self.add_template(
-            ConfigTemplate(name='HTTP_BACKEND_REVPROXY',
+            ConfigTemplate(name='HTTP_BACKEND_REVPROXY_GLUE',
                            value='''\
   acl hdr_location res.hdr(Location) -m found
   rspirep "^Location: (https?://{hostname}(:[0-9]+)?)?(/.*)" "Location: \
@@ -545,9 +544,7 @@ Ex: HAPROXY_0_HTTP_BACKEND_PROXYPASS = '/path/to/redirect
 ''',
                            overridable=True,
                            description='''\
-Set the URL in HTTP response headers sent from a reverse proxied server. \
-It only updates Location, Content-Location and URL.
-Ex: HAPROXY_0_HTTP_BACKEND_REVPROXY = '/my/content'
+Backend glue for `HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH`.
 '''))
 
         self.add_template(
@@ -1038,15 +1035,15 @@ Specified as {specifiedAs}.
             return app.labels['HAPROXY_{0}_BACKEND_SERVER_OPTIONS']
         return self.t['BACKEND_SERVER_OPTIONS'].value
 
-    def haproxy_http_backend_proxypass(self, app):
-        if 'HAPROXY_{0}_HTTP_BACKEND_PROXYPASS' in app.labels:
-            return app.labels['HAPROXY_{0}_HTTP_BACKEND_PROXYPASS']
-        return self.t['HTTP_BACKEND_PROXYPASS'].value
+    def haproxy_http_backend_proxypass_glue(self, app):
+        if 'HAPROXY_{0}_HTTP_BACKEND_PROXYPASS_GLUE' in app.labels:
+            return app.labels['HAPROXY_{0}_HTTP_BACKEND_PROXYPASS_GLUE']
+        return self.t['HTTP_BACKEND_PROXYPASS_GLUE'].value
 
-    def haproxy_http_backend_revproxy(self, app):
-        if 'HAPROXY_{0}_HTTP_BACKEND_REVPROXY' in app.labels:
-            return app.labels['HAPROXY_{0}_HTTP_BACKEND_REVPROXY']
-        return self.t['HTTP_BACKEND_REVPROXY'].value
+    def haproxy_http_backend_revproxy_glue(self, app):
+        if 'HAPROXY_{0}_HTTP_BACKEND_REVPROXY_GLUE' in app.labels:
+            return app.labels['HAPROXY_{0}_HTTP_BACKEND_REVPROXY_GLUE']
+        return self.t['HTTP_BACKEND_REVPROXY_GLUE'].value
 
     def haproxy_http_backend_redir(self, app):
         if 'HAPROXY_{0}_HTTP_BACKEND_REDIR' in app.labels:
@@ -1361,19 +1358,19 @@ roundrobin.
 Ex: `HAPROXY_0_BALANCE = 'leastconn'`
                     '''))
 
-labels.append(Label(name='HTTP_BACKEND_PROXYPASS',
+labels.append(Label(name='HTTP_BACKEND_PROXYPASS_PATH',
                     func=set_proxypath,
                     description='''\
 Set the location to use for mapping local server URLs to remote servers + URL.
-Ex: `HAPROXY_0_HTTP_BACKEND_PROXYPASS = '/path/to/redirect`
+Ex: `HAPROXY_0_HTTP_BACKEND_PROXYPASS_PATH = '/path/to/redirect`
                     '''))
 
-labels.append(Label(name='HTTP_BACKEND_REVPROXY',
+labels.append(Label(name='HTTP_BACKEND_REVPROXY_PATH',
                     func=set_revproxypath,
                     description='''\
 Set the URL in HTTP response headers sent from a reverse proxied server. \
 It only updates Location, Content-Location and URL.
-Ex: `HAPROXY_0_HTTP_BACKEND_REVPROXY = '/my/content'`
+Ex: `HAPROXY_0_HTTP_BACKEND_REVPROXY_PATH = '/my/content'`
                     '''))
 
 labels.append(Label(name='HTTP_BACKEND_REDIR',

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -396,14 +396,14 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
                 backends += templater.haproxy_backend_hsts_options(app)
             backends += templater.haproxy_backend_http_options(app)
             backend_http_backend_proxypass = templater \
-                .haproxy_http_backend_proxypass(app)
+                .haproxy_http_backend_proxypass_glue(app)
             if app.proxypath:
                 backends += backend_http_backend_proxypass.format(
                     hostname=app.hostname,
                     proxypath=app.proxypath
                 )
             backend_http_backend_revproxy = templater \
-                .haproxy_http_backend_revproxy(app)
+                .haproxy_http_backend_revproxy_glue(app)
             if app.revproxypath:
                 backends += backend_http_backend_revproxy.format(
                     hostname=app.hostname,


### PR DESCRIPTION
Renamed `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS` and
`HAPROXY_{n}_HTTP_BACKEND_REVPROXY` labels to
`HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_PATH` and
`HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH` respectively. Also added
equivalent `_GLUE` templates for modifying the actual template.