### PR TITLE
Use `pidof` instead of pidfile w/ reload.

### DIFF
--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -38,7 +38,7 @@ reload() {
   socat /var/run/haproxy/socket - <<< "show servers state" > /var/state/haproxy/global
 
   # Trigger reload
-  haproxy -p $PIDFILE -f /marathon-lb/haproxy.cfg -D -sf $(cat $PIDFILE)
+  haproxy -p $PIDFILE -f /marathon-lb/haproxy.cfg -D -sf $(pidof haproxy)
 
   # Remove the firewall rules
   removeFirewallRules


### PR DESCRIPTION
When doing a graceful reload, use `pidof haproxy` rather than catting
the pidfile to make sure that we send SIGUSR1 to _all_ existing HAProxy
instances.

This is to address #267.