### PR TITLE
Fallback to `ports` on older Marathon versions.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -111,10 +111,12 @@ class ServicePortAssigner(object):
         :return: The list of ports.    Note that if auto-assigning and ports
         become exhausted, a port may be returned as None.
         """
-        ports = filter(lambda p: p is not None,
-                       map(lambda p: p.get('port', None),
-                           app.get('portDefinitions', []))
-                       )
+        ports = app.get('ports', [])
+        if 'portDefinitions' in app:
+            ports = filter(lambda p: p is not None,
+                           map(lambda p: p.get('port', None),
+                               app.get('portDefinitions', []))
+                           )
         ports = list(ports)  # wtf python?
         if not ports and is_ip_per_task(app) and self.can_assign \
                 and len(app['tasks']) > 0:


### PR DESCRIPTION
To address #266.