### PR TITLE
Changing logic to always generate cert

### DIFF
--- a/run
+++ b/run
@@ -45,8 +45,7 @@ if [ -n "${HAPROXY_SSL_CERT-}" ]; then
       SSL_CERTS+=",$certfile"
     fi
   done
-elif [ $ssl_certs_pos -eq 0 ]; then  # if --ssl-certs wasn't passed as arg to this script
-  # if no environment variable or command line argument is provided,
+
   # create self-signed ssl certificate
   openssl genrsa -out /tmp/server-key.pem 2048
   openssl req -new -key /tmp/server-key.pem -out /tmp/server-csr.pem -subj /CN=*/


### PR DESCRIPTION
As per the current code if we specify a  label as,
` HAPROXY_SSL_CERT=/etc/ssl/demo.pem `

Respective haproxy.cfg will be as following with two certs files.
```
frontend marathon_https_in
  bind *:443 ssl crt /etc/ssl/cert.pem crt /etc/ssl/wso2demo.pem
  mode http
```

But the /etc/ssl/cert.pem will not be generated and marathon-lb fails to start. This PR is to always generate certificate and fix the issue.

Else we can remove the logic that append the default cert. [1]

[1] https://github.com/mesosphere/marathon-lb/blob/master/run#L30
