### PR TITLE
marathon_lb: Also check /lib/systemd/system/haproxy.service

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -581,6 +581,7 @@ def reloadConfig():
             logger.debug("we seem to be running on an Upstart based system")
             reloadCommand = ['reload', 'haproxy']
         elif (os.path.isfile('/usr/lib/systemd/system/haproxy.service') or
+              os.path.isfile('/lib/systemd/system/haproxy.service') or
               os.path.isfile('/etc/systemd/system/haproxy.service')):
             logger.debug("we seem to be running on systemd based system")
             reloadCommand = ['systemctl', 'reload', 'haproxy']


### PR DESCRIPTION
This is the correct path of the haproxy service on systems without the
UsrMerge, like Ubuntu / older Debians. This was causing us to take the
init.d path instead of the systemd path on our Ubuntu-based cloud infra.