### PR TITLE
Allow a healthcheck to take place on a specified port index 

### DIFF
--- a/Longhelp.md
+++ b/Longhelp.md
@@ -933,7 +933,8 @@ behind a given service port.
 
 By default, the index will be the same as the one of the service port.
 
-Ex: An app exposes two ports, one for the application, one for its healthchecks:
+Ex: An app exposes two ports, one for the application,
+one for its healthchecks:
 
 portMappings": [
   {

--- a/Longhelp.md
+++ b/Longhelp.md
@@ -923,6 +923,37 @@ The http basic auth definition. For details on configuring auth, see: https://gi
 
 Ex: `HAPROXY_0_AUTH = realm:username:encryptedpassword`
 
+## `HAPROXY_{n}_BACKEND_HEALTHCHECK_PORT_INDEX`
+  *per service port*
+
+Specified as `HAPROXY_{n}_BACKEND_HEALTHCHECK_PORT_INDEX`.
+
+Set the index of the port dedicated for the healthchecks of the backends
+behind a given service port.
+
+By default, the index will be the same as the one of the service port.
+
+Ex: An app exposes two ports, one for the application, one for its healthchecks:
+
+portMappings": [
+  {
+    "containerPort": 9000,
+    "hostPort": 0,
+    "servicePort": 0,
+    "protocol": "tcp"
+  },
+  {
+    "containerPort": 9001,
+    "hostPort": 0,
+    "servicePort": 0,
+    "protocol": "tcp"
+  }
+]
+
+HAPROXY_0_BACKEND_HEALTHCHECK_PORT_INDEX=1 will make it so that the port 9001
+is used to perform the backend healthchecks.
+                    
+
 ## `HAPROXY_{n}_BACKEND_NETWORK_ALLOWED_ACL`
   *per service port*
 

--- a/Longhelp.md
+++ b/Longhelp.md
@@ -92,7 +92,7 @@ optional arguments:
                         ports for IP-per-task applications (default: 10100)
   --syslog-socket SYSLOG_SOCKET
                         Socket to write syslog messages to. Use '/dev/null' to
-                        disable logging to syslog (default: /var/run/syslog)
+                        disable logging to syslog (default: /dev/log)
   --log-format LOG_FORMAT
                         Set log message format (default: %(name)s:
                         %(message)s)

--- a/config.py
+++ b/config.py
@@ -1417,7 +1417,8 @@ behind a given service port.
 
 By default, the index will be the same as the one of the service port.
 
-Ex: An app exposes two ports, one for the application, one for its healthchecks:
+Ex: An app exposes two ports, one for the application,
+one for its healthchecks:
 
 portMappings": [
   {

--- a/config.py
+++ b/config.py
@@ -1139,6 +1139,10 @@ def set_port(x, k, v):
     x.servicePort = int(v)
 
 
+def set_healthcheck_port_index(x, k, v):
+    x.healthcheck_port_index = int(v)
+
+
 def set_backend_weight(x, k, v):
     x.backend_weight = int(v)
 
@@ -1405,6 +1409,35 @@ By default every IP is allowed.
 Ex: `HAPROXY_0_BACKEND_NETWORK_ALLOWED_ACL = '127.0.0.1/8, 10.1.55.43'`
                     '''))
 
+labels.append(Label(name='BACKEND_HEALTHCHECK_PORT_INDEX',
+                    func=set_healthcheck_port_index,
+                    description='''\
+Set the index of the port dedicated for the healthchecks of the backends
+behind a given service port.
+
+By default, the index will be the same as the one of the service port.
+
+Ex: An app exposes two ports, one for the application, one for its healthchecks:
+
+portMappings": [
+  {
+    "containerPort": 9000,
+    "hostPort": 0,
+    "servicePort": 0,
+    "protocol": "tcp"
+  },
+  {
+    "containerPort": 9001,
+    "hostPort": 0,
+    "servicePort": 0,
+    "protocol": "tcp"
+  }
+]
+
+HAPROXY_0_BACKEND_HEALTHCHECK_PORT_INDEX=1 will make it so that the port 9001
+is used to perform the backend healthchecks.
+                    ''',
+                    ))
 labels.append(Label(name='FRONTEND_HEAD',
                     func=set_label,
                     description=''))

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -115,6 +115,7 @@ class MarathonService(object):
         self.labels = {}
         self.backend_weight = 0
         self.network_allowed = None
+        self.healthcheck_port_index = None
         if healthCheck:
             if healthCheck['protocol'] == 'HTTP':
                 self.mode = 'http'
@@ -275,6 +276,49 @@ def has_group(groups, app_groups):
         return True
 
     return False
+
+
+def get_backend_port(apps, app, idx):
+    """
+    Return the port of the idx-th backend of the app which index in apps
+    is defined by app.healthcheck_port_index.
+
+    Example case:
+        We define an app mapping two ports: 9000 and 9001, that we
+        scaled to 3 instances.
+        The port 9000 is used for the app itself, and the port 9001
+        is used for the app healthchecks. Hence, we have 2 apps
+        at the marathon level, each with 3 backends (one for each
+        container).
+
+        If app.healthcheck_port_index is set to 1 (via the
+        HAPROXY_0_BACKEND_HEALTHCHECK_PORT_INDEX label), then
+        get_backend_port(apps, app, 3) will return the port of the 3rd
+        backend of the second app.
+
+    See https://github.com/mesosphere/marathon-lb/issues/198 for the
+    actual use case.
+
+    Note: if app.healthcheck_port_index has a out of bounds value,
+    then the app idx-th backend is returned instead.
+
+    """
+    def get_backends(app):
+        key_func = attrgetter('host', 'port')
+        return sorted(list(app.backends), key=key_func)
+
+    apps = [_app for _app in apps if _app.appId == app.appId]
+
+    # If no healthcheck port index is defined, or if its value is nonsense
+    # simply return the app port
+    if app.healthcheck_port_index is None or abs(app.healthcheck_port_index) > len(apps):
+        return get_backends(app)[idx].port
+
+    # If a healthcheck port index is defined, fetch the app corresponding
+    # to the argument app healthcheck port index, and return its idx-th backend port
+    apps = sorted(apps, key=attrgetter('appId', 'servicePort'))
+    backends = get_backends(apps[app.healthcheck_port_index])
+    return backends[idx].port
 
 
 def config(apps, groups, bind_http_https, ssl_certs, templater,
@@ -439,37 +483,6 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
                     format(network_allowed=network)
             backends += templater.haproxy_tcp_backend_acl_allow_deny
 
-        if app.healthCheck:
-            health_check_options = None
-            if app.mode == 'tcp' or app.healthCheck['protocol'] == 'TCP':
-                health_check_options = templater \
-                    .haproxy_backend_tcp_healthcheck_options(app)
-            elif app.mode == 'http':
-                health_check_options = templater \
-                    .haproxy_backend_http_healthcheck_options(app)
-            if health_check_options:
-                healthCheckPort = app.healthCheck.get('port')
-                backends += health_check_options.format(
-                    healthCheck=app.healthCheck,
-                    healthCheckPortIndex=app.healthCheck.get('portIndex'),
-                    healthCheckPort=healthCheckPort,
-                    healthCheckProtocol=app.healthCheck['protocol'],
-                    healthCheckPath=app.healthCheck.get('path', '/'),
-                    healthCheckTimeoutSeconds=app.healthCheck[
-                        'timeoutSeconds'],
-                    healthCheckIntervalSeconds=app.healthCheck[
-                        'intervalSeconds'],
-                    healthCheckIgnoreHttp1xx=app.healthCheck['ignoreHttp1xx'],
-                    healthCheckGracePeriodSeconds=app.healthCheck[
-                        'gracePeriodSeconds'],
-                    healthCheckMaxConsecutiveFailures=app.healthCheck[
-                        'maxConsecutiveFailures'],
-                    healthCheckFalls=app.healthCheck[
-                        'maxConsecutiveFailures'] + 1,
-                    healthCheckPortOptions=' port ' +
-                    str(healthCheckPort) if healthCheckPort else ''
-                )
-
         if app.sticky:
             logger.debug("turning on sticky sessions")
             backends += templater.haproxy_backend_sticky_options(app)
@@ -477,8 +490,42 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
         frontend_backend_glue = templater.haproxy_frontend_backend_glue(app)
         frontends += frontend_backend_glue.format(backend=backend)
 
+        do_healthcheck_options_once = True
         key_func = attrgetter('host', 'port')
-        for backendServer in sorted(app.backends, key=key_func):
+        for backend_service_idx, backendServer in enumerate(sorted(app.backends, key=key_func)):
+            if do_healthcheck_options_once:
+                if app.healthCheck:
+                    health_check_options = None
+                    if app.mode == 'tcp' or app.healthCheck['protocol'] == 'TCP':
+                        health_check_options = templater \
+                            .haproxy_backend_tcp_healthcheck_options(app)
+                    elif app.mode == 'http':
+                        health_check_options = templater \
+                            .haproxy_backend_http_healthcheck_options(app)
+                    if health_check_options:
+                        healthCheckPort = get_backend_port(apps, app, backend_service_idx)
+                        backends += health_check_options.format(
+                            healthCheck=app.healthCheck,
+                            healthCheckPortIndex=app.healthCheck.get('portIndex'),
+                            healthCheckPort=healthCheckPort,
+                            healthCheckProtocol=app.healthCheck['protocol'],
+                            healthCheckPath=app.healthCheck.get('path', '/'),
+                            healthCheckTimeoutSeconds=app.healthCheck[
+                                'timeoutSeconds'],
+                            healthCheckIntervalSeconds=app.healthCheck[
+                                'intervalSeconds'],
+                            healthCheckIgnoreHttp1xx=app.healthCheck['ignoreHttp1xx'],
+                            healthCheckGracePeriodSeconds=app.healthCheck[
+                                'gracePeriodSeconds'],
+                            healthCheckMaxConsecutiveFailures=app.healthCheck[
+                                'maxConsecutiveFailures'],
+                            healthCheckFalls=app.healthCheck[
+                                                 'maxConsecutiveFailures'] + 1,
+                            healthCheckPortOptions=' port ' +
+                                                   str(healthCheckPort) if healthCheckPort else ''
+                        )
+                do_healthcheck_options_once = False
+
             logger.debug(
                 "backend server %s:%d on %s",
                 backendServer.ip,
@@ -512,7 +559,7 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
                     server_health_check_options = templater \
                         .haproxy_backend_server_http_healthcheck_options(app)
                 if server_health_check_options:
-                    healthCheckPort = app.healthCheck.get('port')
+                    healthCheckPort = get_backend_port(apps, app, backend_service_idx)
                     healthCheckOptions = server_health_check_options.format(
                         healthCheck=app.healthCheck,
                         healthCheckPortIndex=app.healthCheck.get('portIndex'),
@@ -1302,6 +1349,25 @@ def get_apps(marathon):
                     func(service,
                          key_unformatted,
                          marathon_app.app['labels'][key])
+
+            # https://github.com/mesosphere/marathon-lb/issues/198
+            # Marathon app manifest which defines healthChecks is defined for a specific given
+            # service port identified by either a port or portIndex.
+            # (Marathon itself will prefer port before portIndex
+            #  https://mesosphere.github.io/marathon/docs/health-checks.html)
+            #
+            # We want to be able to instruct HAProxy to use health check defined for service port B
+            #  in marathon to indicate service port A is healthy or not for service port A in HAProxy.
+            #
+            # This is done by specifying a label:
+            #  HAPROXY_{n}_BACKEND_HEALTHCHECK_PORT_INDEX
+            #
+            # TODO(norangshol) Refactor and supply MarathonService with its labels and do this in its constructor?
+            if service.healthCheck is None and service.healthcheck_port_index is not None:
+                service.healthCheck = get_health_check(app, service.healthcheck_port_index)
+                if service.healthCheck:
+                    if service.healthCheck['protocol'] == 'HTTP':
+                        service.mode = 'http'
 
             marathon_app.services[servicePort] = service
 

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -361,6 +361,11 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
                 continue
 
         logger.debug("configuring app %s", app.appId)
+        if len(app.backends) < 1:
+            logger.error("skipping app %s as it is not valid to generate" +
+                         " backend without any server entries!", app.appId)
+            continue
+
         backend = app.appId[1:].replace('/', '_') + '_' + str(app.servicePort)
 
         logger.debug("frontend at %s:%d with backend %s",

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -1309,6 +1309,238 @@ backend nginx_10000
 '''
         self.assertMultiLineEqual(config, expected)
 
+    def test_config_simple_app_healthcheck_port_using_another_portindex(self):
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 0,
+            "gracePeriodSeconds": 10,
+            "intervalSeconds": 2,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "ignoreHttp1xx": False
+        }
+        app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app.groups = ['external']
+        app.add_backend("agent1", "192.0.2.1", 1024, False)
+        app.healthcheck_port_index = 1
+        admin_app = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        admin_app.groups = ['external']
+        admin_app.add_backend("agent1", "192.0.2.1", 1025, False)
+        apps = [app, admin_app]
+
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+  acl app__nginx hdr(x-marathon-app-id) -i /nginx
+  use_backend nginx_10000 if app__nginx
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode http
+  use_backend nginx_10000
+
+frontend nginx_10001
+  bind *:10001
+  mode http
+  use_backend nginx_10001
+
+backend nginx_10000
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+  server agent1_192_0_2_1_1024 192.0.2.1:1024 check inter 2s fall 11 port 1025
+
+backend nginx_10001
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+  server agent1_192_0_2_1_1025 192.0.2.1:1025 check inter 2s fall 11
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_simple_app_healthcheck_port_diff_portindex_and_group(self):
+        apps = dict()
+        groups = ['external', 'internal']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 0,
+            "gracePeriodSeconds": 10,
+            "intervalSeconds": 2,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "ignoreHttp1xx": False
+        }
+        app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app.groups = ['external']
+        app.add_backend("agent1", "192.0.2.1", 1024, False)
+        app.healthcheck_port_index = 1
+        admin_app = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        admin_app.groups = ['internal']
+        admin_app.add_backend("agent1", "192.0.2.1", 1025, False)
+        apps = [app, admin_app]
+
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+  acl app__nginx hdr(x-marathon-app-id) -i /nginx
+  use_backend nginx_10000 if app__nginx
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode http
+  use_backend nginx_10000
+
+frontend nginx_10001
+  bind *:10001
+  mode http
+  use_backend nginx_10001
+
+backend nginx_10000
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+  server agent1_192_0_2_1_1024 192.0.2.1:1024 check inter 2s fall 11 port 1025
+
+backend nginx_10001
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+  server agent1_192_0_2_1_1025 192.0.2.1:1025 check inter 2s fall 11
+'''
+        self.assertMultiLineEqual(config, expected)
+
+    def test_config_simple_app_healthcheck_port_portindex_out_of_range(self):
+        """
+        see marathon_lb.get_backend_port(apps, app, idx) for impl.
+
+        if app.healthcheck_port_index has a out of bounds value,
+        then the app idx-th backend is returned instead.
+        :return:
+        """
+        apps = dict()
+        groups = ['external']
+        bind_http_https = True
+        ssl_certs = ""
+        templater = marathon_lb.ConfigTemplater()
+
+        healthCheck = {
+            "path": "/",
+            "protocol": "HTTP",
+            "portIndex": 0,
+            "gracePeriodSeconds": 10,
+            "intervalSeconds": 2,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "ignoreHttp1xx": False
+        }
+        app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
+        app.groups = ['external']
+        app.add_backend("agent1", "192.0.2.1", 1024, False)
+        app.healthcheck_port_index = 3
+        admin_app = marathon_lb.MarathonService('/nginx', 10001, healthCheck)
+        admin_app.groups = ['external']
+        admin_app.add_backend("agent1", "192.0.2.1", 1025, False)
+        apps = [app, admin_app]
+
+        config = marathon_lb.config(apps, groups, bind_http_https,
+                                    ssl_certs, templater)
+        expected = self.base_config + '''
+frontend marathon_http_in
+  bind *:80
+  mode http
+
+frontend marathon_http_appid_in
+  bind *:9091
+  mode http
+  acl app__nginx hdr(x-marathon-app-id) -i /nginx
+  use_backend nginx_10000 if app__nginx
+
+frontend marathon_https_in
+  bind *:443 ssl crt /etc/ssl/mesosphere.com.pem
+  mode http
+
+frontend nginx_10000
+  bind *:10000
+  mode http
+  use_backend nginx_10000
+
+frontend nginx_10001
+  bind *:10001
+  mode http
+  use_backend nginx_10001
+
+backend nginx_10000
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+  server agent1_192_0_2_1_1024 192.0.2.1:1024 check inter 2s fall 11 port 1024
+
+backend nginx_10001
+  balance roundrobin
+  mode http
+  option forwardfor
+  http-request set-header X-Forwarded-Port %[dst_port]
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  option  httpchk GET /
+  timeout check 10s
+  server agent1_192_0_2_1_1025 192.0.2.1:1025 check inter 2s fall 11
+'''
+        self.assertMultiLineEqual(config, expected)
+
     def test_config_simple_app_tcp_healthcheck(self):
         apps = dict()
         groups = ['external']

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -337,6 +337,7 @@ backend nginx_10000
         app = marathon_lb.MarathonService('/nginx', 10000, healthCheck)
         app.hostname = "test.example.com,test"
         app.groups = ['external']
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -374,6 +375,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -459,6 +461,7 @@ backend nginx_10000
         app.hostname = "test.example.com,test"
         app.groups = ['external']
         app.redirectHttpToHttps = True
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -496,6 +499,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -594,6 +598,7 @@ backend nginx_10000
         app.authUser = "testuser"
         app.authPasswd = "testpasswd"
         app.groups = ['external']
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -643,6 +648,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -745,6 +751,7 @@ backend nginx_10000
         app.authRealm = "realm"
         app.authUser = "testuser"
         app.authPasswd = "testpasswd"
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -797,6 +804,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -884,6 +892,7 @@ backend nginx_10000
         app.hostname = "test.example.com,test"
         app.path = '/some/path'
         app.groups = ['external']
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -924,6 +933,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1014,6 +1024,7 @@ backend nginx_10000
         app.path = '/some/path'
         app.groups = ['external']
         app.redirectHttpToHttps = True
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -1055,6 +1066,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1081,6 +1093,7 @@ backend nginx_10000
         app.groups = ['external']
         app.redirectHttpToHttps = True
         app.useHsts = True
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         apps = [app]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -1123,6 +1136,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 
@@ -1714,12 +1728,16 @@ backend nginx_10000
         app1 = copy.deepcopy(app)
         app2 = copy.deepcopy(app)
         app3 = copy.deepcopy(app)
+        app.add_backend("agent1", "192.0.2.1", 1234, False)
         app1.backend_weight = 1
         app1.appId += '1'
+        app1.add_backend("agent1", "192.0.2.1", 2234, False)
         app2.backend_weight = 2
         app2.appId += '2'
+        app2.add_backend("agent1", "192.0.2.1", 3234, False)
         app3.backend_weight = 3
         app3.appId += '3'
+        app3.add_backend("agent1", "192.0.2.1", 4234, False)
         apps = [app, app1, app2, app3]
 
         config = marathon_lb.config(apps, groups, bind_http_https,
@@ -1801,6 +1819,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_1234 192.0.2.1:1234 check inter 2s fall 11
 
 backend nginx1_10000
   balance roundrobin
@@ -1810,6 +1829,7 @@ backend nginx1_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_2234 192.0.2.1:2234 check inter 2s fall 11
 
 backend nginx2_10000
   balance roundrobin
@@ -1819,6 +1839,7 @@ backend nginx2_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_3234 192.0.2.1:3234 check inter 2s fall 11
 
 backend nginx3_10000
   balance roundrobin
@@ -1828,6 +1849,7 @@ backend nginx3_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   option  httpchk GET /
   timeout check 10s
+  server agent1_192_0_2_1_4234 192.0.2.1:4234 check inter 2s fall 11
 '''
         self.assertMultiLineEqual(config, expected)
 


### PR DESCRIPTION
See issue #198 for details.

Use case:

```
Ex: An app exposes two ports, one for the application, one for its healthchecks:

portMappings": [
  {
    "containerPort": 9000,
    "hostPort": 0,
    "servicePort": 0,
    "protocol": "tcp"
  },
  {
    "containerPort": 9001,
    "hostPort": 0,
    "servicePort": 0,
    "protocol": "tcp"
  }
]

HAPROXY_0_BACKEND_HEALTHCHECK_PORT_INDEX=1 will make it so that the port 9001
is used to perform the backend healthchecks.
```

This is a usual pattern to expose administrative contexts on it's own port when using http://www.dropwizard.io/ . 

cc @brouberol as the original author of the original patch used at OVH. 

(we're currently testing this in our staging environment here at Zedge) 