### PR TITLE
added support for maximum seconds to wait before failing if deployment is stuck

### DIFF
--- a/zdd.py
+++ b/zdd.py
@@ -353,12 +353,12 @@ def swap_zdd_apps(args, new_app, old_app):
     if deployment_in_progress(new_app):
         if global_retry_time_counter < args.fail_wait:
             time.sleep(args.step_delay)
-            global_retry_time_counter+=args.step_delay
+            global_retry_time_counter += args.step_delay
             return swap_zdd_apps(args, new_app, old_app)
         else:
             raise Exception("The deployment seems to be"
-                        " stucked. Kindly remove the stucked deployment")
-    
+                            " stucked. Kindly remove the stucked deployment")
+
     tasks_to_kill = find_tasks_to_kill(args, new_app, old_app, time.time())
 
     if ready_to_delete_old_app(args, new_app, old_app, tasks_to_kill):
@@ -739,10 +739,10 @@ def get_arg_parser():
                         help="Resume from a previous deployment",
                         action="store_true"
                         )
-    parser.add_argument("--fail-wait", "-t",       
-                        help="Total time to wait before failing to deploy"      
-                        " the application",     
-                        type=int, default=120       
+    parser.add_argument("--fail-wait", "-t",
+                        help="Total time to wait before failing to deploy"
+                        " the application",
+                        type=int, default=120
                         )
     parser.add_argument("--max-wait", "-w",
                         help="Maximum amount of time (in seconds) to wait"


### PR DESCRIPTION
This is the PR for the issue: #311 

A new command-line parameter is added `--fail-wait` which describes the total time in seconds to wait before failing to deploy the application. This is used if the deployment for blue-green is stuck if a particular task is not becoming healthy. This allows ZDD script to fail fast, instead of waiting till stack overflow happens for the recursive call to `swap_zdd_apps()`.
