### PR TITLE
Correctly create haproxy chain

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -660,6 +660,7 @@ def reloadConfig():
             subprocess.check_call(reloadCommand, close_fds=True)
             # Wait until the reload actually occurs and there's a new PID
             while len(get_haproxy_pids() - old_pids) < 1:
+                logger.info("Waiting for new haproxy pid...") # TODO: remove. Only for debugging.
                 time.sleep(0.1)
             logger.debug("reload finished, took %s seconds",
                          time.time() - start_time)

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -660,7 +660,7 @@ def reloadConfig():
             subprocess.check_call(reloadCommand, close_fds=True)
             # Wait until the reload actually occurs and there's a new PID
             while len(get_haproxy_pids() - old_pids) < 1:
-                logger.info("Waiting for new haproxy pid...") # TODO: remove. Only for debugging.
+                logger.info("Waiting for new haproxy pid...")
                 time.sleep(0.1)
             logger.debug("reload finished, took %s seconds",
                          time.time() - start_time)

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -660,7 +660,7 @@ def reloadConfig():
             subprocess.check_call(reloadCommand, close_fds=True)
             # Wait until the reload actually occurs and there's a new PID
             while len(get_haproxy_pids() - old_pids) < 1:
-                logger.info("Waiting for new haproxy pid...")
+                logger.debug("Waiting for new haproxy pid...")
                 time.sleep(0.1)
             logger.debug("reload finished, took %s seconds",
                          time.time() - start_time)

--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -32,10 +32,10 @@ reload() {
     socat /var/run/haproxy/socket - <<< "show servers state" > /var/state/haproxy/global
 
     # Trigger reload
-    CURRENT_HAPROXY_PID=$(cat $PIDFILE)
-    haproxy -p $PIDFILE -f /marathon-lb/haproxy.cfg -D -sf $CURRENT_HAPROXY_PID 200>&-
+    LATEST_HAPROXY_PID=$(cat $PIDFILE)
+    haproxy -p $PIDFILE -f /marathon-lb/haproxy.cfg -D -sf $LATEST_HAPROXY_PID 200>&-
     if [ -n "${HAPROXY_RELOAD_SIGTERM_DELAY-}" ]; then
-      sleep $HAPROXY_RELOAD_SIGTERM_DELAY && kill $CURRENT_HAPROXY_PID 200>&- 2>/dev/null &
+      sleep $HAPROXY_RELOAD_SIGTERM_DELAY && kill $LATEST_HAPROXY_PID 200>&- 2>/dev/null &
     fi
 
     # Remove the firewall rules

--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -32,10 +32,10 @@ reload() {
     socat /var/run/haproxy/socket - <<< "show servers state" > /var/state/haproxy/global
 
     # Trigger reload
-    HAPROXY_PIDS=$(pidof haproxy)
-    haproxy -p $PIDFILE -f /marathon-lb/haproxy.cfg -D -sf $HAPROXY_PIDS 200>&-
+    CURRENT_HAPROXY_PID=$(cat $PIDFILE)
+    haproxy -p $PIDFILE -f /marathon-lb/haproxy.cfg -D -sf $CURRENT_HAPROXY_PID 200>&-
     if [ -n "${HAPROXY_RELOAD_SIGTERM_DELAY-}" ]; then
-      sleep $HAPROXY_RELOAD_SIGTERM_DELAY && kill $HAPROXY_PIDS 200>&- 2>/dev/null &
+      sleep $HAPROXY_RELOAD_SIGTERM_DELAY && kill $CURRENT_HAPROXY_PID 200>&- 2>/dev/null &
     fi
 
     # Remove the firewall rules


### PR DESCRIPTION
Don't use `pidof haproxy` as input to the `-sf` argument.

`pidof haproxy` can return multiple pids instead of the latest haproxy pid, which can break the reload chain. 

This will hopefully fix the problem where MLB hangs indefinitely and stops refreshing the haproxy config.

Added log message while waiting for new haproxy pid as we have seen the loop to run forever before. Without this print out the user knows nothing about the state of MLB.

Similar problems:
* https://groups.google.com/forum/#!topic/marathon-framework/R6RkBHaFtBo
* https://github.com/QubitProducts/bamboo/issues/79