### PR TITLE
HAproxy build improvements

### DIFF
--- a/build-haproxy.sh
+++ b/build-haproxy.sh
@@ -32,6 +32,8 @@ make -j4 \
   CPU=x86_64 \
   USE_PCRE=1 \
   USE_PCRE_JIT=1 \
+  USE_REGPARM=1 \
+  USE_STATIC_PCRE=1 \
   USE_OPENSSL=1 \
   USE_LUA=1 \
   LUA_LIB=/usr/local/lib/ \

--- a/build-haproxy.sh
+++ b/build-haproxy.sh
@@ -36,9 +36,8 @@ make -j4 \
   USE_LUA=1 \
   LUA_LIB=/usr/local/lib/ \
   LUA_INC=/usr/local/include/ \
-  USE_ZLIB=1 \
-  LDFLAGS="-lcrypt  -lssl -lcrypto -L/usr/local/lib/ -llua -lm -L/usr/lib -lpcreposix -lpcre"
-make -j4 install-bin LDFLAGS="-lcrypt  -lssl -lcrypto -L/usr/local/lib/ -llua -lm -L/usr/lib -lpcreposix -lpcre -ldl"
+  USE_ZLIB=1
+make -j4 install-bin
 
 # Clean up
 cd /

--- a/build-haproxy.sh
+++ b/build-haproxy.sh
@@ -32,11 +32,7 @@ make -j4 \
   CPU=x86_64 \
   USE_PCRE=1 \
   USE_PCRE_JIT=1 \
-  USE_LIBCRYPT=1 \
-  USE_LINUX_SPLICE=1 \
-  USE_LINUX_TPROXY=1 \
   USE_OPENSSL=1 \
-  USE_DL=1 \
   USE_LUA=1 \
   LUA_LIB=/usr/local/lib/ \
   LUA_INC=/usr/local/include/ \

--- a/build-haproxy.sh
+++ b/build-haproxy.sh
@@ -37,7 +37,7 @@ make -j4 \
   LUA_LIB=/usr/local/lib/ \
   LUA_INC=/usr/local/include/ \
   USE_ZLIB=1
-make -j4 install-bin
+make install-bin
 
 # Clean up
 cd /


### PR DESCRIPTION
Probably best read commit-by-commit.

Before (`mesosphere/marathon-lb:v1.4.2`):
```
root@2bc441c311bf:/marathon-lb# haproxy -vv
HA-Proxy version 1.6.9 2016/08/30
Copyright 2000-2016 Willy Tarreau <willy@haproxy.org>

Build options :
  TARGET  = linux2628
  CPU     = x86_64
  CC      = gcc
  CFLAGS  = -g -fno-strict-aliasing -Wdeclaration-after-statement
  OPTIONS = USE_LINUX_SPLICE=1 USE_LINUX_TPROXY=1 USE_LIBCRYPT=1 USE_ZLIB=1 USE_DL=1 USE_OPENSSL=1 USE_LUA=1 USE_PCRE=1 USE_PCRE_JIT=1

Default settings :
  maxconn = 2000, bufsize = 16384, maxrewrite = 1024, maxpollevents = 200

Encrypted password support via crypt(3): yes
Built with zlib version : 1.2.8
Compression algorithms supported : identity("identity"), deflate("deflate"), raw-deflate("deflate"), gzip("gzip")
Built with OpenSSL version : OpenSSL 1.0.2j  26 Sep 2016
Running on OpenSSL version : OpenSSL 1.0.2j  26 Sep 2016
OpenSSL library supports TLS extensions : yes
OpenSSL library supports SNI : yes
OpenSSL library supports prefer-server-ciphers : yes
Built with PCRE version : 8.39 2016-06-14
PCRE library supports JIT : yes
Built with Lua version : Lua 5.3.3
Built with transparent proxy support using: IP_TRANSPARENT IPV6_TRANSPARENT IP_FREEBIND

Available polling systems :
      epoll : pref=300,  test result OK
       poll : pref=200,  test result OK
     select : pref=150,  test result OK
Total: 3 (3 usable), will use epoll.

root@2bc441c311bf:/marathon-lb# ldd $(which haproxy)
        linux-vdso.so.1 (0x00007ffe8dffa000)
        libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007fb02d469000)
        libssl.so.1.0.2 => /lib/x86_64-linux-gnu/libssl.so.1.0.2 (0x00007fb02d1ff000)
        libcrypto.so.1.0.2 => /lib/x86_64-linux-gnu/libcrypto.so.1.0.2 (0x00007fb02cd9b000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb02ca97000)
        libpcreposix.so.3 => /lib/x86_64-linux-gnu/libpcreposix.so.3 (0x00007fb02c894000)
        libpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x00007fb02c61f000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fb02c404000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fb02c200000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb02be62000)
        /lib64/ld-linux-x86-64.so.2 (0x000055c0c3051000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fb02bc45000)
```

After:
```
root@6355d9ae7068:/marathon-lb# haproxy -vv
HA-Proxy version 1.6.9 2016/08/30
Copyright 2000-2016 Willy Tarreau <willy@haproxy.org>

Build options :
  TARGET  = linux2628
  CPU     = x86_64
  CC      = gcc
  CFLAGS  = -g -fno-strict-aliasing -Wdeclaration-after-statement
  OPTIONS = USE_ZLIB=1 USE_REGPARM=1 USE_OPENSSL=1 USE_LUA=1 USE_STATIC_PCRE=1 USE_PCRE_JIT=1

Default settings :
  maxconn = 2000, bufsize = 16384, maxrewrite = 1024, maxpollevents = 200

Encrypted password support via crypt(3): yes
Built with zlib version : 1.2.8
Compression algorithms supported : identity("identity"), deflate("deflate"), raw-deflate
("deflate"), gzip("gzip")
Built with OpenSSL version : OpenSSL 1.0.2j  26 Sep 2016
Running on OpenSSL version : OpenSSL 1.0.2j  26 Sep 2016
OpenSSL library supports TLS extensions : yes
OpenSSL library supports SNI : yes
OpenSSL library supports prefer-server-ciphers : yes
Built with PCRE version : 8.39 2016-06-14
PCRE library supports JIT : yes
Built with Lua version : Lua 5.3.3
Built with transparent proxy support using: IP_TRANSPARENT IPV6_TRANSPARENT IP_FREEBIND

Available polling systems :
      epoll : pref=300,  test result OK
       poll : pref=200,  test result OK
     select : pref=150,  test result OK
Total: 3 (3 usable), will use epoll.

root@6355d9ae7068:/marathon-lb# ldd $(which haproxy)
        linux-vdso.so.1 (0x00007ffcee7db000)
        libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007f929bfb4000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f929bd9a000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f929bb96000)
        libssl.so.1.0.2 => /usr/lib/x86_64-linux-gnu/libssl.so.1.0.2 (0x00007f929b92c000)
        libcrypto.so.1.0.2 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.2 (0x00007f929b4c8000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f929b1c2000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f929ae24000)
        /lib64/ld-linux-x86-64.so.2 (0x00005577d22b1000)
```