### PR TITLE
Use PycURL for fetching event streams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ FROM debian:stretch
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         iptables \
+        libcurl3 \
         liblua5.3-0 \
+        libssl1.0.2 \
+        openssl \
         procps \
         python3 \
         runit \
@@ -37,6 +40,7 @@ COPY requirements.txt /marathon-lb/
 RUN set -x \
     && buildDeps=' \
         gcc \
+        libcurl4-openssl-dev \
         libffi-dev \
         liblua5.3-dev \
         libpcre3-dev \

--- a/README.md
+++ b/README.md
@@ -86,14 +86,6 @@ newer versions.
 
 Syntax: `docker run mesosphere/marathon-lb sse [other args]`
 
-#### `event` mode
-**NOTE**: `event` mode is deprecated and will be removed from marathon-lb in future releases.
-
-In event mode, the script registers a HTTP callback in marathon to get
-notified when state changes.
-
-Syntax: `docker run mesosphere/marathon-lb event callback-addr:port [other args]`
-
 #### `poll` mode
 If you can't use the HTTP callbacks, the script can poll the APIs to get
 the schedulers state periodically.

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -50,7 +50,8 @@ from common import (get_marathon_auth_params, set_logging_args,
                     set_marathon_auth_args, setup_logging)
 from config import ConfigTemplater, label_keys
 from lrucache import LRUCache
-from utils import get_task_ip_and_ports, ServicePortAssigner, set_ip_cache
+from utils import (CurlHttpEventStream, get_task_ip_and_ports,
+                   ServicePortAssigner, set_ip_cache)
 
 
 logger = logging.getLogger('marathon_lb')
@@ -238,17 +239,7 @@ class Marathon(object):
         logger.info(
             "SSE Active, trying fetch events from {0}".format(url))
 
-        headers = {
-            'Cache-Control': 'no-cache',
-            'Accept': 'text/event-stream'
-        }
-
-        resp = requests.get(url,
-                            stream=True,
-                            headers=headers,
-                            timeout=(3.05, 46),
-                            auth=self.__auth,
-                            verify=self.__verify)
+        resp = CurlHttpEventStream(url, self.__auth, self.__verify)
 
         class Event(object):
             def __init__(self, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cryptography
 PyJWT==1.4.0
+pycurl
 python-dateutil
 requests
 six

--- a/run
+++ b/run
@@ -82,17 +82,8 @@ case "$MODE" in
   sse)
     ARGS="--sse"
     ;;
-  event)
-    URL=$1; shift
-    if [ -z "$URL" ] || echo "$URL" | grep -q '^-'; then
-      echo "$0 event callback-url [marathon_lb.py args]" >&2
-      exit 1
-    fi
-    echo "Using $URL as event callback-url"
-    ARGS="-u $URL"
-    ;;
   *)
-    echo "Unknown mode $MODE. Synopsis: $0 poll|sse|event [marathon_lb.py args]" >&2
+    echo "Unknown mode $MODE. Synopsis: $0 poll|sse [marathon_lb.py args]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
Earlier issues #35 and #114 made things better in this department. However,
when running marathon-lb with a large (400+ applications) marathon instance,
there are still problems.

These problems can be traced back to Python itself, unfortunately:
http://stackoverflow.com/questions/21797753/efficiently-reading-lines-from-compressed-chunked-http-stream-as-they-arrive

Python requests uses urllib under the covers, and there are implicit issues
when 7.5 MB of JSON comes back on a single line, as we're seeing when certain
events are emitted. These events are deployment_info and deployment_success at
a minimum, there may be more.

By switching to PycURL, as noted in the Stack Overflow post, we bypass this
whole issue. We use an HTTP library that handles this particular edge case
well, reducing CPU usage dramatically when a large event comes in. It also
handles gzip compression, which means any 7.5 MB JSON dumps should shrink
significantly.

One unsolved problem remains here: the addition of DC/OS authentication support
in #285 is extremely tightly coupled to internal implementation details of the
python requests module. This simply won't work with this code, and I have zero
ability to fix or test it as we don't use DC/OS.