### PR TITLE
haproxy_wrapper fixes.

### DIFF
--- a/haproxy_wrapper.py
+++ b/haproxy_wrapper.py
@@ -7,6 +7,8 @@ import errno
 
 def create_haproxy_pipe():
     pipefd = os.pipe()
+    os.set_inheritable(pipefd[0], True)
+    os.set_inheritable(pipefd[1], True)
     return pipefd
 
 
@@ -24,6 +26,7 @@ def wait_on_haproxy_pipe(pipefd):
         if len(ret) == 0:
             close_and_swallow(pipefd[0])
             close_and_swallow(pipefd[1])
+            return False
     except OSError as e:
         if e.args[0] != errno.EINTR:
             close_and_swallow(pipefd[0])

--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -33,7 +33,7 @@ reload() {
 
     # Trigger reload
     LATEST_HAPROXY_PID=$(cat $PIDFILE)
-    /marathon-lb/haproxy_wrapper.py `which haproxy` -p $PIDFILE -f /marathon-lb/haproxy.cfg -sf $LATEST_HAPROXY_PID 200>&-
+    /marathon-lb/haproxy_wrapper.py `which haproxy` -D -p $PIDFILE -f /marathon-lb/haproxy.cfg -sf $LATEST_HAPROXY_PID 200>&-
     local exit_code=$?
     if [ $exit_code -ne 0 ]; then
       echo "HAProxy reload failed" 1>&2


### PR DESCRIPTION
 - set pipe to inheritable (this changed in Python 3.4, and I missed it
   in my previous testing)
 - run HAProxy in daemon mode (durr)