### PR TITLE
Fix pycurl SSL Verification

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -166,6 +166,9 @@ class CurlHttpEventStream(object):
             self.curl.setopt(pycurl.USERPWD, '%s:%s' % auth)
         if verify:
             self.curl.setopt(pycurl.CAINFO, verify)
+        else:
+            self.curl.setopt(pycurl.SSL_VERIFYHOST, 0)
+            self.curl.setopt(pycurl.SSL_VERIFYPEER, 0)
 
         self.curl.setopt(pycurl.HTTPHEADER, headers)
 

--- a/utils.py
+++ b/utils.py
@@ -165,7 +165,7 @@ class CurlHttpEventStream(object):
             self.curl.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_BASIC)
             self.curl.setopt(pycurl.USERPWD, '%s:%s' % auth)
         if verify:
-            self.curl.setopt(pycurl.CA_INFO, verify)
+            self.curl.setopt(pycurl.CAINFO, verify)
 
         self.curl.setopt(pycurl.HTTPHEADER, headers)
 


### PR DESCRIPTION
World's smallest PR :1st_place_medal:

This changes `CurlHttpEventStream` to have the same SSL verification behavior as `Marathon`.

Context: I'm running DC/OS Enterprise Edition (1.8.7) and MLB v1.5.0. I wanted to configure MLB to use HTTPS, but since DC/OS uses it's own internal CA, the certs aren't valid.

Standard API requests through the `Marathon` object work fine because it disables SSL verification by default.

```python
self.__verify = False
if ca_cert:
    self.__verify = ca_cert
```

Using server side events fails because `CurlHttpEventStream` does not disable SSL verification by default.

```
2017-02-27 15:39:27,165 marathon_lb: starting event processor thread
2017-02-27 15:39:27,166 marathon_lb: SSE Active, trying fetch events from https://marathon.mesos:8443/v2/events
2017-02-27 15:39:27,219 marathon_lb: Caught exception
Traceback (most recent call last):
  File "/marathon-lb/marathon_lb.py", line 1746, in <module>
    process_sse_events(marathon, processor)
  File "/marathon-lb/marathon_lb.py", line 1651, in process_sse_events
    for event in events:
  File "/marathon-lb/marathon_lb.py", line 238, in get_event_stream
    for line in resp.iter_lines():
  File "/marathon-lb/utils.py", line 227, in _split_lines_from_chunks
    for chunk in chunks:
  File "/marathon-lb/utils.py", line 212, in _iter_chunks
    self._check_curl_errors()
  File "/marathon-lb/utils.py", line 216, in _check_curl_errors
    raise pycurl.error(*f[1:])
pycurl.error: (60, 'SSL certificate problem: self signed certificate in certificate chain')
```

Explicitly adding the CA via `--marathon-ca-cert` works for `Marathon` but `CurlHttpEventStream` has a typo.

```
2017-02-27 15:54:20,370 marathon_lb: SSE Active, trying fetch events from https://marathon.mesos:8443/v2/events
2017-02-27 15:54:20,370 marathon_lb: Caught exception
Traceback (most recent call last):
  File "/marathon-lb/marathon_lb.py", line 1746, in <module>
    process_sse_events(marathon, processor)
  File "/marathon-lb/marathon_lb.py", line 1651, in process_sse_events
    for event in events:
  File "/marathon-lb/marathon_lb.py", line 232, in get_event_stream
    resp = CurlHttpEventStream(url, self.__auth, self.__verify)
  File "/marathon-lb/utils.py", line 168, in __init__
    self.curl.setopt(pycurl.CA_INFO, verify)
AttributeError: module 'pycurl' has no attribute 'CA_INFO'
```