### PR TITLE
use consistent line endings when comparing config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1165,7 +1165,7 @@ def set_balance(x, k, v):
 
 
 def set_label(x, k, v):
-    x.labels[k] = v
+    x.labels[k] = normalize_line_endings(v)
 
 
 def set_group(x, k, v):
@@ -1186,6 +1186,11 @@ def set_redirpath(x, k, v):
 
 def set_network_allowed(x, k, v):
     x.network_allowed = v
+
+# remove any line-ending inconsistencies
+# https://github.com/mesosphere/marathon-lb/pull/430
+def normalize_line_endings(v):
+    return v.replace("\r\n", "\n")
 
 
 class Label:

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -601,9 +601,7 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
     config += frontends
     config += backends
 
-    # python replaces '\r\n' with '\n' on read in text mode
-    # replace it here to get consistent comparison
-    return config.replace('\r\n', '\n')
+    return config
 
 
 def get_haproxy_pids():

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -601,7 +601,9 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
     config += frontends
     config += backends
 
-    return config
+    # python replaces '\r\n' with '\n' on read in text mode
+    # replace it here to get consistent comparison
+    return config.replace('\r\n', '\n')
 
 
 def get_haproxy_pids():


### PR DESCRIPTION
Since python replaces `\r\n` with `\n` when [reading files in text mode](https://docs.python.org/3.5/tutorial/inputoutput.html#reading-and-writing-files), any `\r\n` combinations provided in custom marathon labels will cause the configuration to always appear 'changed' when compared with the string read from the config file on disk.

This change assures consistent line endings are used during comparison to avoid unnecessary reloads.

Before this fix is applied, using this example config (from the wiki) or similar (containing `\r\n`) will cause the config to be seen as 'changed' every time a check is performed:
```
{
  "id":"app",
  "labels":{
    "HAPROXY_GROUP":"external",
    "HAPROXY_0_BACKEND_HEAD":"backend {backend}\r\n  balance {balance}\r\n  mode {mode}\r\n  timeout server 30m\r\n  timeout client 30m\r\n"
  }
}
```

