### PR TITLE
Get --auth-credentials from a VAULT instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ It is possible to pass `--auth-credentials=` option if your Marathon requires au
 $ ./marathon_lb.py --marathon http://localhost:8080 --auth-credentials=admin:password
 ```
 
+It is possible to get the auth credentials (user & password) from VAULT if you define the following 
+environment variables before running marathon-lb: VAULT_TOKEN, VAULT_HOST, VAULT_PORT, VAULT_PATH 
+where VAULT_PATH is the root path where your user and password are located.
+
 This will refresh `haproxy.cfg`, and if there were any changes, then it will
 automatically reload HAProxy. Only apps with the label `HAPROXY_GROUP=external`
 will be exposed on this LB.

--- a/run
+++ b/run
@@ -88,6 +88,13 @@ case "$MODE" in
     ;;
 esac
 
+if [ -n "${VAULT_TOKEN-}" ] && [ -n "${VAULT_HOST-}" ] && [ -n "${VAULT_PORT-}" ] && [ -n "${VAULT_PATH-}" ]; then
+  export MARATHON_LB_USER=$(curl -k -L -H "X-Vault-Token:$VAULT_TOKEN"  "https://$VAULT_HOST:$VAULT_PORT$VAULT_PATH" -s | jq -r ".data .\"user\"")
+  export MARATHON_LB_PASSWORD=$(curl -k -L -H "X-Vault-Token:$VAULT_TOKEN"  "https://$VAULT_HOST:$VAULT_PORT$VAULT_PATH" -s | jq -r ".data .\"pass\"")
+  export CREDENTIALS="$MARATHON_LB_USER:$MARATHON_LB_PASSWORD"
+  ARGS="$ARGS --auth-credentials $CREDENTIALS"
+fi
+
 for arg in "$@"; do
     escaped=$(printf %q "$arg")
     ARGS="$ARGS $escaped"


### PR DESCRIPTION
As you might know if your Marathon requires authentication it is possible to pass in the auth-credentials parameter to marathon_lb.py in order to get authorized.

This PR includes the changes to get the user & password from a running VAULT instance defining environment variables. If this PR gets approved we will able to add these variables to the config.json of the marathon-lb package in the DC/OS universe.