### PR TITLE
Fix ordering of acls that include paths when using haproxy map with https

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -774,6 +774,7 @@ def generateHttpVhostAcl(
                 else:
                     if haproxy_map:
                         if 'map_https_frontend_acl' not in duplicate_map:
+                            app.backend_weight = -1
                             https_frontend_acl = templater.\
                                 haproxy_map_https_frontend_acl(app)
                             staging_https_frontends += https_frontend_acl.\


### PR DESCRIPTION
This issue doesn't surface when the equivalent http rules are used because the map is given a different weight: https://github.com/mesosphere/marathon-lb/blob/v1.6.0/marathon_lb.py#L723

The same weighting is not given to the https map in this particular block, which sometimes injects the map in the middle of the path acls. Everywhere else the weight is added, so this must have just been missed?