### PR TITLE
fix bug: marathon-lb not found marathon leader in multiple marathon server

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -184,7 +184,8 @@ class Marathon(object):
             )
 
             logger.debug("%s %s", method, response.url)
-            if response.status_code == 200:
+            if response.status_code == 200 \
+                    and response.headers.get('X-Marathon-Leader', None):
                 break
 
         response.raise_for_status()


### PR DESCRIPTION
if parameter --marathon have multiple marathon server and first marathon server is not leader, initialization procedure will throw exception