### PR TITLE
increase REQURI_LEN to 4096

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN set -x \
         USE_REGPARM=1 \
         USE_STATIC_PCRE=1 \
         USE_ZLIB=1 \
+        DEFINE=-DREQURI_LEN=4096 \
         all \
         install-bin \
     && rm -rf /usr/src/haproxy \


### PR DESCRIPTION
Haproxy default request uri len is 1024.
With longer uris, which is not so rare, logs are truncated.
This PR increase this value to 4096 at compile time.

http://marc.info/?t=143332172000001&r=1&w=2