### PR TITLE
avoid iterating possible None returned by 'get_app_port_mappings'

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -360,6 +360,8 @@ def get_ip_address_discovery_ports(app):
 
 def get_port_mapping_ports(app):
     port_mappings = get_app_port_mappings(app)
+    if port_mappings is None:
+        return None
     task_ports = [p['containerPort']
                   for p in port_mappings
                   if 'containerPort' in p]


### PR DESCRIPTION
This PR fixes an error seen when utils.py attempts to iterate None:
```
2017-08-18 16:43:34,454 marathon_lb: Unexpected error!
Traceback (most recent call last):
  File "/marathon-lb/marathon_lb.py", line 1517, in do_reset
    self.__apps = get_apps(self.__marathon)
  File "/marathon-lb/marathon_lb.py", line 1414, in get_apps
    task_ip, task_ports = get_task_ip_and_ports(app, task)
  File "/marathon-lb/utils.py", line 407, in get_task_ip_and_ports
    task_ports = get_app_task_ports(app, task, mode)
  File "/marathon-lb/utils.py", line 385, in get_app_task_ports
    return get_port_mapping_ports(app)
  File "/marathon-lb/utils.py", line 364, in get_port_mapping_ports
    for p in port_mappings
TypeError: 'NoneType' object is not iterable
```