### PR TITLE
Bind the backend to the frontend when redirectHttpToHttps is used

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1195,10 +1195,11 @@ def generateHttpVhostAcl(
         else:
             if app.redirectHttpToHttps:
                 http_frontend_acl = \
-                    templater.haproxy_http_frontend_acl_only(app)
+                    templater.haproxy_http_frontend_acl(app)
                 staging_http_frontends += http_frontend_acl.format(
                     cleanedUpHostname=acl_name,
-                    hostname=app.hostname
+                    hostname=app.hostname,
+                    backend=backend
                 )
                 haproxy_backend_redirect_http_to_https = \
                     templater.\

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -454,6 +454,7 @@ frontend marathon_http_in
   bind *:80
   mode http
   acl host_test_example_com_nginx hdr(host) -i test.example.com
+  use_backend nginx_10000 if host_test_example_com_nginx
   redirect scheme https code 301 if !{ ssl_fc } host_test_example_com_nginx
 
 frontend marathon_http_appid_in


### PR DESCRIPTION
Currently, using the `HAPROXY_REDIRECT_TO_HTTPS` label together with a (single) virtual host doesn't work because the `use_backend` config isn't added. It seems that `haproxy_http_frontend_acl_only` is being used instead of `haproxy_http_frontend_acl` in one of the paths.
