### PR TITLE
Typo on HAPROXY_HTTP_BACKEND_REVPROXY_GLUE template.

### DIFF
--- a/Longhelp.md
+++ b/Longhelp.md
@@ -800,7 +800,7 @@ Backend glue for `HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH`.
 **Default template for `HAPROXY_HTTP_BACKEND_REVPROXY_GLUE`:**
 ```
   acl hdr_location res.hdr(Location) -m found
-  rspirep "^Location: (https?://{hostname}(:[0-9]+)?)?(/.*)" "Location:   {rootpath} if hdr_location"
+  rspirep "^Location: (https?://{hostname}(:[0-9]+)?)?(/.*)" "Location:   {rootpath}" if hdr_location
 ```
 **Example Marathon label to override `HAPROXY_HTTP_BACKEND_REVPROXY_GLUE` for the first port of a given app:**
 ```

--- a/config.py
+++ b/config.py
@@ -604,7 +604,7 @@ Backend glue for `HAPROXY_{n}_HTTP_BACKEND_PROXYPASS_PATH`.
                            value='''\
   acl hdr_location res.hdr(Location) -m found
   rspirep "^Location: (https?://{hostname}(:[0-9]+)?)?(/.*)" "Location: \
-  {rootpath} if hdr_location"
+  {rootpath}" if hdr_location
 ''',
                            overridable=True,
                            description='''\

--- a/tests/test_marathon_lb.py
+++ b/tests/test_marathon_lb.py
@@ -1973,7 +1973,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   acl hdr_location res.hdr(Location) -m found
   rspirep "^Location: (https?://test.example.com(:[0-9]+)?)?(/.*)" "Location: \
-  /test if hdr_location"
+  /test" if hdr_location
   server agent1_1_1_1_1_1024 1.1.1.1:1024 id 28363
 '''
         self.assertMultiLineEqual(config, expected)
@@ -2986,7 +2986,7 @@ backend nginx_10000
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   acl hdr_location res.hdr(Location) -m found
   rspirep "^Location: (https?://None(:[0-9]+)?)?(/.*)" \
-"Location:   /proxy/path if hdr_location"
+"Location:   /proxy/path" if hdr_location
   option  httpchk GET /
   timeout check 10s
   server agent1_1_1_1_1_1024 1.1.1.1:1024 id 28363 check inter 2s fall 11


### PR DESCRIPTION
Due to a wrong end double quote location in the HAPROXY_HTTP_BACKEND_REVPROXY_GLUE template, it option was generating the haproxy configuration erroneously and making the HAPROXY_{n}_HTTP_BACKEND_REVPROXY_PATH option have unexpected behavior.

I double checked with the [HAProxy Documentation](https://www.haproxy.com/doc/aloha/7.0/haproxy/http_rewriting.html#rewrite-anywhere-in-the-response-using-regexes)
`rspirep <search> <replace> [<cond>]`
