### PR TITLE
Add container syslogd support and fix 'Waiting for Pids' race condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:stretch
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
+        inetutils-syslogd \
         iptables \
         libcurl3 \
         liblua5.3-0 \

--- a/Longhelp.md
+++ b/Longhelp.md
@@ -18,8 +18,9 @@ Marathon-lb just needs to know where to find Marathon.
 ```
 usage: marathon_lb.py [-h] [--longhelp] [--marathon MARATHON [MARATHON ...]]
                       [--haproxy-config HAPROXY_CONFIG] [--group GROUP]
-                      [--command COMMAND] [--strict-mode] [--sse]
-                      [--health-check]
+                      [--command COMMAND] [--retry-reload]
+                      [--reload-interval RELOAD_INTERVAL] [--strict-mode]
+                      [--sse] [--health-check]
                       [--lru-cache-capacity LRU_CACHE_CAPACITY]
                       [--haproxy-map] [--dont-bind-http-https]
                       [--ssl-certs SSL_CERTS] [--skip-validation] [--dry]
@@ -51,6 +52,11 @@ optional arguments:
   --command COMMAND, -c COMMAND
                         If set, run this command to reload haproxy. (default:
                         None)
+  --retry-reload        Retry reload if unsuccessful after --reload-interval
+                        seconds. (default: False)
+  --reload-interval RELOAD_INTERVAL
+                        When --retry-reload enabled, wait this long before
+                        attempting another reload. (default: 10)
   --strict-mode         If set, backends are only advertised if
                         HAPROXY_{n}_ENABLED=true. Strict mode will be enabled
                         by default in a future release. (default: False)

--- a/Longhelp.md
+++ b/Longhelp.md
@@ -18,7 +18,8 @@ Marathon-lb just needs to know where to find Marathon.
 ```
 usage: marathon_lb.py [-h] [--longhelp] [--marathon MARATHON [MARATHON ...]]
                       [--haproxy-config HAPROXY_CONFIG] [--group GROUP]
-                      [--command COMMAND] [--retry-reload]
+                      [--command COMMAND]
+                      [--max-reload-retries MAX_RELOAD_RETRIES]
                       [--reload-interval RELOAD_INTERVAL] [--strict-mode]
                       [--sse] [--health-check]
                       [--lru-cache-capacity LRU_CACHE_CAPACITY]
@@ -52,11 +53,13 @@ optional arguments:
   --command COMMAND, -c COMMAND
                         If set, run this command to reload haproxy. (default:
                         None)
-  --retry-reload        Retry reload if unsuccessful after --reload-interval
-                        seconds. (default: False)
+  --max-reload-retries MAX_RELOAD_RETRIES
+                        Max reload retries before failure. Reloads happen
+                        every --reload-interval seconds. Set to 0 to disable
+                        or -1 for infinite retries. (default: 10)
   --reload-interval RELOAD_INTERVAL
-                        When --retry-reload enabled, wait this long before
-                        attempting another reload. (default: 10)
+                        Wait this number of seconds betwee nreload retries.
+                        (default: 10)
   --strict-mode         If set, backends are only advertised if
                         HAPROXY_{n}_ENABLED=true. Strict mode will be enabled
                         by default in a future release. (default: False)

--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ The default value when not specified is `redispatch,http-server-close,dontlognul
   < HTTP/1.1 200 OK
   ```
  * Some of the features of marathon-lb assume that it is the only instance of itself running in a PID namespace. i.e. marathon-lb assumes that it is running in a container. Certain features like the `/_mlb_signal` endpoints and the `/_haproxy_getpids` endpoint (and by extension, zero-downtime deployments) may behave unexpectedly if more than one instance of marathon-lb is running in the same PID namespace or if there are other HAProxy processes in the same PID namespace.
+ * Sometimes it is desirable to get detailed container and HAProxy logging for easier debugging as well as viewing connection logging to frontends and backends. This can be achieved by setting the `HAPROXY_SYSLOGD` environment variable or `container-syslogd` value in `options.json` like so:
+ 
+ ```json
+   {
+     "marathon-lb": {
+       "container-syslogd": true
+     }
+   }
+ ```
+
 
 ## Zero-downtime Deployments
 

--- a/haproxy_wrapper.py
+++ b/haproxy_wrapper.py
@@ -12,6 +12,7 @@ consoleHandler = logging.StreamHandler()
 consoleHandler.setFormatter(formatter)
 logger.addHandler(consoleHandler)
 
+
 def create_haproxy_pipe():
     logger.debug("create_haproxy_pipe called")
     pipefd = os.pipe()

--- a/haproxy_wrapper.py
+++ b/haproxy_wrapper.py
@@ -3,35 +3,52 @@ import os
 import sys
 import time
 import errno
+import logging
 
+logger = logging.getLogger('haproxy_wrapper')
+logger.setLevel(getattr(logging, 'DEBUG'))
+formatter = logging.Formatter("%(asctime)-15s %(name)s: %(message)s")
+consoleHandler = logging.StreamHandler()
+consoleHandler.setFormatter(formatter)
+logger.addHandler(consoleHandler)
 
 def create_haproxy_pipe():
+    logger.debug("create_haproxy_pipe called")
     pipefd = os.pipe()
     os.set_inheritable(pipefd[0], True)
     os.set_inheritable(pipefd[1], True)
+    logger.debug("create_haproxy_pipe done")
     return pipefd
 
 
 def close_and_swallow(fd):
+    logger.debug("close_and_swallow called")
     try:
         os.close(fd)
-    except OSError:
+        logger.debug("close_and_swallow successful")
+    except OSError as e:
         # swallow
+        logger.debug("close_and_swallow swallow OSError: %s", e)
         pass
 
 
 def wait_on_haproxy_pipe(pipefd):
+    logger.debug("wait_on_haproxy_pipe called")
     try:
         ret = os.read(pipefd[0], 1)
         if len(ret) == 0:
             close_and_swallow(pipefd[0])
             close_and_swallow(pipefd[1])
+            logger.debug("wait_on_haproxy_pipe done (False)")
             return False
     except OSError as e:
+        logger.debug("wait_on_haproxy_pipe OSError: %s", e)
         if e.args[0] != errno.EINTR:
             close_and_swallow(pipefd[0])
             close_and_swallow(pipefd[1])
+            logger.debug("wait_on_haproxy_pipe done (False)")
             return False
+    logger.debug("wait_on_haproxy_pipe done (True)")
     return True
 
 

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -662,8 +662,9 @@ def reloadConfig():
                     break
                 timeSinceCheckpoint = time.time() - checkpoint_time
                 if (timeSinceCheckpoint >= reload_frequency):
-                    logger.debug("Still waiting for new haproxy pid after %s " +
-                                 "seconds (old pids: [%s], new_pids: [%s]).",
+                    logger.debug("Still waiting for new haproxy pid after " +
+                                 "%s seconds (old pids: [%s], " +
+                                 "new_pids: [%s]).",
                                  time.time() - start_time, old_pids, new_pids)
                     checkpoint_time = time.time()
                     if args.retry_reload:
@@ -1626,7 +1627,7 @@ def get_arg_parser():
                         help="Retry reload if unsuccessful after "
                         "--reload-interval seconds.", action="store_true")
     parser.add_argument("--reload-interval",
-                        help="When --retry-reload enabled, wait this"
+                        help="When --retry-reload enabled, wait this "
                         "long before attempting another reload.",
                         type=int, default=10)
     parser.add_argument("--strict-mode",

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -648,7 +648,7 @@ def reloadConfig():
         try:
             start_time = time.time()
             checkpoint_time = start_time
-            log_frequency = 60 # Log every 60 seconds
+            reload_frequency = 10 # Retry the reload every 10 seconds
             old_pids = get_haproxy_pids()
             subprocess.check_call(reloadCommand, close_fds=True)
             new_pids = get_haproxy_pids()
@@ -660,10 +660,11 @@ def reloadConfig():
                 if len(new_pids - old_pids) >= 1:
                     break
                 timeSinceCheckpoint = time.time() - checkpoint_time
-                if (timeSinceCheckpoint >= log_frequency):
+                if (timeSinceCheckpoint >= reload_frequency):
                     logger.debug("Still waiting for new haproxy pid after %s seconds (old pids: [%s], " +
-                                 "new_pids: [%s])...", time.time() - start_time, old_pids, new_pids)
+                                 "new_pids: [%s]). Attempting reload again...", time.time() - start_time, old_pids, new_pids)
                     checkpoint_time = time.time()
+                    subprocess.check_call(reloadCommand, close_fds=True)
                 time.sleep(0.1)
             new_pids = get_haproxy_pids()
             logger.debug("new pids: [%s]", new_pids)

--- a/run
+++ b/run
@@ -1,6 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
+log() {
+    msg="$1"
+
+    logline="[$(pwd) $0] $msg\n"
+
+    printf "$logline" >&1
+    printf "$logline" >&2
+}
+
+# A hack to redirect syslog to stdout.
+# This is necessary because haproxy only logs to syslog.
+ln -sf /proc/$$/fd/1 /var/log/container_stdout
+
+# Start syslog
+/usr/sbin/syslogd -f "/marathon-lb/syslogd/syslog.conf"
+
+# Custom syslog socket for marathon-lb.py logging
 SYSLOG_SOCKET=${SYSLOG_SOCKET:-/dev/null}
 
 LB_SERVICE="/marathon-lb/service/lb"
@@ -10,9 +27,9 @@ HAPROXY_SERVICE="/marathon-lb/service/haproxy"
 mkdir -p $HAPROXY_SERVICE/env
 
 if [ -n "${PORTS-}" ]; then
-  echo $PORTS > $HAPROXY_SERVICE/env/PORTS
+  log "$PORTS > $HAPROXY_SERVICE/env/PORTS"
 else
-  echo 'Define $PORTS with a comma-separated list of ports to which HAProxy binds' >&2
+  log "Define $PORTS with a comma-separated list of ports to which HAProxy binds"
   exit 1
 fi
 
@@ -64,7 +81,7 @@ if [ -n "${MESOS_SANDBOX-}" ] && [ -d "$MESOS_SANDBOX/templates" ]; then
 fi
 
 if [ -n "${HAPROXY_SYSCTL_PARAMS-}" ]; then
-  echo "setting sysctl params to: ${HAPROXY_SYSCTL_PARAMS}"
+  log "setting sysctl params to: ${HAPROXY_SYSCTL_PARAMS}"
   if [ -n "${HAPROXY_SYSCTL_NONSTRICT-}" ]; then
     # ignore errors
     sysctl -w $HAPROXY_SYSCTL_PARAMS || true
@@ -83,12 +100,12 @@ case "$MODE" in
     ARGS="--sse"
     ;;
   *)
-    echo "Unknown mode $MODE. Synopsis: $0 poll|sse [marathon_lb.py args]" >&2
+    log "Unknown mode $MODE. Synopsis: $0 poll|sse [marathon_lb.py args]"
     exit 1
     ;;
 esac
 
-if [ -n "${VAULT_TOKEN-}" ] && [ -n "${VAULT_HOST-}" ] && [ -n "${VAULT_PORT-}" ] && [ -n "${VAULT_PATH-}" ]; then 
+if [ -n "${VAULT_TOKEN-}" ] && [ -n "${VAULT_HOST-}" ] && [ -n "${VAULT_PORT-}" ] && [ -n "${VAULT_PATH-}" ]; then
   MARATHON_LB_PASSWORD=$(curl -k -L -H "X-Vault-Token:$VAULT_TOKEN" "$VAULT_URL" -s| python -m json.tool | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["data"]["pass"]')
   MARATHON_LB_USER=$(curl -k -L -H "X-Vault-Token:$VAULT_TOKEN" "$VAULT_URL" -s | python -m json.tool | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["data"]["user"]')
   CREDENTIALS="$MARATHON_LB_USER:$MARATHON_LB_PASSWORD"
@@ -112,6 +129,12 @@ exec /marathon-lb/marathon_lb.py \
     $ARGS
 EOF
 chmod 755 $LB_SERVICE/run
+
+log "Created $LB_SERVICE/run with contents:"
+LB_RUN=$(cat $LB_SERVICE/run)
+log ""
+log "$LB_RUN"
+log ""
 
 if [ "${MODE}" == "poll" ]; then
 

--- a/run
+++ b/run
@@ -1,24 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+LOG_PREFIX="$(pwd) $0"
 log() {
-    msg="$1"
-
-    logline="[$(pwd) $0] $msg\n"
-
+    logline="[$LOG_PREFIX] $1\n"
+    printf "$logline" >&1
+}
+log_error() {
+    logline="[$LOG_PREFIX] $1\n"
     printf "$logline" >&1
     printf "$logline" >&2
 }
 
 if [ -n "${HAPROXY_SYSLOGD-}" ]; then
-    log "starting syslogd with container stdout"
-
-    # A hack to redirect syslog to stdout.
-    # This is necessary because haproxy only logs to syslog.
-    ln -sf /proc/$$/fd/1 /var/log/container_stdout
-
-    # Start syslog
-    /usr/sbin/syslogd -f "/marathon-lb/syslogd/syslog.conf"
+    SYSLOGD_SERVICE="/marathon-lb/service/syslogd"
+    mkdir -p $SYSLOGD_SERVICE
+    cp /marathon-lb/syslogd/run "$SYSLOGD_SERVICE/"
 fi
 
 # Custom syslog socket for marathon-lb.py logging
@@ -33,7 +30,7 @@ mkdir -p $HAPROXY_SERVICE/env
 if [ -n "${PORTS-}" ]; then
   log "$PORTS > $HAPROXY_SERVICE/env/PORTS"
 else
-  log "Define $PORTS with a comma-separated list of ports to which HAProxy binds"
+  log_error "Define $PORTS with a comma-separated list of ports to which HAProxy binds"
   exit 1
 fi
 
@@ -104,7 +101,7 @@ case "$MODE" in
     ARGS="--sse"
     ;;
   *)
-    log "Unknown mode $MODE. Synopsis: $0 poll|sse [marathon_lb.py args]"
+    log_error "Unknown mode $MODE. Synopsis: $0 poll|sse [marathon_lb.py args]"
     exit 1
     ;;
 esac
@@ -136,9 +133,7 @@ chmod 755 $LB_SERVICE/run
 
 log "Created $LB_SERVICE/run with contents:"
 LB_RUN=$(cat $LB_SERVICE/run)
-log ""
 log "$LB_RUN"
-log ""
 
 if [ "${MODE}" == "poll" ]; then
 

--- a/run
+++ b/run
@@ -10,12 +10,16 @@ log() {
     printf "$logline" >&2
 }
 
-# A hack to redirect syslog to stdout.
-# This is necessary because haproxy only logs to syslog.
-ln -sf /proc/$$/fd/1 /var/log/container_stdout
+if [ -n "${HAPROXY_SYSLOGD-}" ]; then
+    log "starting syslogd with container stdout"
 
-# Start syslog
-/usr/sbin/syslogd -f "/marathon-lb/syslogd/syslog.conf"
+    # A hack to redirect syslog to stdout.
+    # This is necessary because haproxy only logs to syslog.
+    ln -sf /proc/$$/fd/1 /var/log/container_stdout
+
+    # Start syslog
+    /usr/sbin/syslogd -f "/marathon-lb/syslogd/syslog.conf"
+fi
 
 # Custom syslog socket for marathon-lb.py logging
 SYSLOG_SOCKET=${SYSLOG_SOCKET:-/dev/null}

--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -2,11 +2,13 @@
 exec 2>&1
 export PIDFILE="/tmp/haproxy.pid"
 
+LOG_PREFIX="$(pwd) $0"
 log() {
-    msg="$1"
-
-    logline="[$(pwd) $0] $msg\n"
-
+    logline="[$LOG_PREFIX] $1\n"
+    printf "$logline" >&1
+}
+log_error() {
+    logline="[$LOG_PREFIX] $1\n"
     printf "$logline" >&1
     printf "$logline" >&2
 }
@@ -53,7 +55,7 @@ reload() {
     local exit_code=$?
     log "exit code: $exit_code"
     if [ $exit_code -ne 0 ]; then
-      log "HAProxy reload failed"
+      log_error "HAProxy reload failed"
     fi
 
     log "Removing firewall rules with removeFirewallRules"

--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -2,6 +2,15 @@
 exec 2>&1
 export PIDFILE="/tmp/haproxy.pid"
 
+log() {
+    msg="$1"
+
+    logline="[$(pwd) $0] $msg\n"
+
+    printf "$logline" >&1
+    printf "$logline" >&2
+}
+
 addFirewallRules() {
   IFS=',' read -ra ADDR <<< "$PORTS"
   for i in "${ADDR[@]}"; do
@@ -17,30 +26,39 @@ removeFirewallRules() {
 }
 
 reload() {
-  echo "Reloading haproxy"
+  log "Reloading haproxy"
 
   (
     flock 200
 
-    # Begin to drop SYN packets with firewall rules
+    log "Dropping SYN packets with addFirewallRules"
     addFirewallRules
 
     # Wait to settle
     sleep 0.1
+    log "addFirewallRules done"
 
-    # Save the current HAProxy state
+    log "Saving the current HAProxy state"
     socat /var/run/haproxy/socket - <<< "show servers state" > /var/state/haproxy/global
+    log "Done saving the current HAProxy state"
 
     # Trigger reload
     LATEST_HAPROXY_PID=$(cat $PIDFILE)
-    /marathon-lb/haproxy_wrapper.py `which haproxy` -D -p $PIDFILE -f /marathon-lb/haproxy.cfg -sf $LATEST_HAPROXY_PID 200>&-
+    log "LATEST_HAPROXY_PID: [$LATEST_HAPROXY_PID]"
+
+    WHICH_HAPROXY=$(which haproxy)
+
+    log "/marathon-lb/haproxy_wrapper.py $WHICH_HAPROXY -D -p $PIDFILE -f /marathon-lb/haproxy.cfg -sf $LATEST_HAPROXY_PID 200>&-"
+    /marathon-lb/haproxy_wrapper.py $WHICH_HAPROXY -D -p $PIDFILE -f /marathon-lb/haproxy.cfg -sf $LATEST_HAPROXY_PID 200>&-
     local exit_code=$?
+    log "exit code: $exit_code"
     if [ $exit_code -ne 0 ]; then
-      echo "HAProxy reload failed" 1>&2
+      log "HAProxy reload failed"
     fi
 
-    # Remove the firewall rules
+    log "Removing firewall rules with removeFirewallRules"
     removeFirewallRules
+    log "removeFirewallRules done"
 
     # Need to wait 1s to prevent TCP SYN exponential backoff
     sleep 1

--- a/service/haproxy/run
+++ b/service/haproxy/run
@@ -62,6 +62,8 @@ reload() {
 
     # Need to wait 1s to prevent TCP SYN exponential backoff
     sleep 1
+
+    log "Reload finished"
   ) 200>/var/run/haproxy/lock
 }
 

--- a/syslogd/run
+++ b/syslogd/run
@@ -1,0 +1,9 @@
+#!/bin/bash
+exec 2>&1
+
+# A hack to redirect syslog to stdout.
+# This is necessary because haproxy only logs to syslog.
+ln -sf /proc/$$/fd/1 /var/log/container_stdout
+
+# Start syslog in foreground
+/usr/sbin/syslogd -f "/marathon-lb/syslogd/syslog.conf" -n

--- a/syslogd/syslog.conf
+++ b/syslogd/syslog.conf
@@ -1,0 +1,1 @@
+*.*;auth,authpriv.none          -/var/log/container_stdout


### PR DESCRIPTION
Corresponding config changes can be found here: https://github.com/mesosphere/universe/pull/1462

* Address various race conditions resulting in never-ending `Waiting for pid...`: Added these args:

```
  --retry-reload        Retry reload if unsuccessful after --reload-interval
                        seconds. (default: False)
  --reload-interval RELOAD_INTERVAL
                        When --retry-reload enabled, wait this long before
                        attempting another reload. (default: 10)
```
* Address `[ALERT] 278/182040 (164) : sendmsg logger #1 failed: No such file or directory (errno=2)` and `[ALERT] 278/182040 (164) : sendmsg logger #2 failed: No such file or directory (errno=2)`: Enable syslogd logging to container stdout (default to off) by setting the `HAPROXY_SYSLOGD` environment variable or `container-syslogd` value in `options.json` like so:
 
 ```json
   {
     "marathon-lb": {
       "container-syslogd": true
     }
   }
 ```