### PR TITLE
Update debian version for v1.8.1 (DO NOT MERGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 \
         runit \
         gnupg-agent \
+        libdpkg-perl \
         socat \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         procps \
         python3 \
         runit \
+        gnupg-agent \
         socat \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Triggering a build for v1.8.1, which is based on v1.8.0, but updated to cover security bugfixes.

Marathon-LB v1.9.0+ are incompatible with DC/OS 1.8.x.