### PR TITLE
add missing dependency so python requirements compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         inetutils-syslogd \
         iptables \
         libcurl3 \
+        libdpkg-perl \
         liblua5.3-0 \
         libssl1.0.2 \
         openssl \


### PR DESCRIPTION
On the current master branch (HEAD https://github.com/mesosphere/marathon-lb/commit/b2a7c7f2efd2c4bb27790206c3dd22bc9911b385), the docker build fails with the following error:

```
x86_64-linux-gnu-gcc: error: /usr/share/dpkg/no-pie-compile.specs: No such file or directory
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-ikrjk52o/pycurl/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-xlnkzo6o-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-ikrjk52o/pycurl/
```

The file `no-pie-compile.specs` in debian buster is in the `libdpkg-perl` package. Adding this package to the build dependencies in the Dockerfile fixes the issue, and the build completes as expected.