### PR TITLE
health_status_changed_event removed to reduce reloads

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1593,7 +1593,6 @@ class MarathonEventProcessor(object):
 
     def handle_event(self, event):
         if event['eventType'] == 'status_update_event' or \
-                event['eventType'] == 'health_status_changed_event' or \
                 event['eventType'] == 'api_post_event':
             self.reset_from_tasks()
 


### PR DESCRIPTION
Ignore `health_status_changed_event`, as it will be followed by `status_update_event` and mlb will eventually reload when status_update event is triggered. Also since HAProxy has its own health check, the task will be OOR on HAP so this event can be ignored. This reduces the number of reloads in a large setup and hence saves end user from frequent 5xx if there are containers dying frequently.