### PR TITLE
Fix reconnect logging and timing depending on error type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY requirements.txt /marathon-lb/
 
 RUN set -x \
     && buildDeps=' \
+        build-essential \
         gcc \
         libcurl4-openssl-dev \
         libffi-dev \

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -41,6 +41,7 @@ from tempfile import mkstemp
 
 import dateutil.parser
 import requests
+import pycurl
 
 from common import (get_marathon_auth_params, set_logging_args,
                     set_marathon_auth_args, setup_logging, cleanup_json)
@@ -1160,8 +1161,9 @@ def truncateMapFileIfExists(map_file):
         os.ftruncate(fd, 0)
         os.close(fd)
 
+
 def generateAndValidateConfig(config, config_file, domain_map_array,
-                                app_map_array, haproxy_map):
+                              app_map_array, haproxy_map):
     domain_map_file = os.path.join(os.path.dirname(config_file),
                                    "domain2backend.map")
     app_map_file = os.path.join(os.path.dirname(config_file),
@@ -1169,7 +1171,6 @@ def generateAndValidateConfig(config, config_file, domain_map_array,
 
     domain_map_string = str()
     app_map_string = str()
-    runningConfig = str()
 
     if haproxy_map:
         domain_map_string = generateMapString(domain_map_array)
@@ -1178,15 +1179,13 @@ def generateAndValidateConfig(config, config_file, domain_map_array,
     return writeConfigAndValidate(
                 config, config_file, domain_map_string, domain_map_file,
                 app_map_string, app_map_file, haproxy_map)
-            
 
 
 def compareWriteAndReloadConfig(config, config_file, domain_map_array,
                                 app_map_array, haproxy_map):
-    
     changed = False
     config_valid = False
-    
+
     # See if the last config on disk matches this, and if so don't reload
     # haproxy
     domain_map_file = os.path.join(os.path.dirname(config_file),
@@ -1249,7 +1248,7 @@ def compareWriteAndReloadConfig(config, config_file, domain_map_array,
             changed = False
             config_valid = True
             logger.debug("skipping reload: config unchanged")
-    
+
     return changed, config_valid
 
 
@@ -1521,31 +1520,32 @@ def regenerate_config(marathon, config_file, groups, bind_http_https,
                               templater, haproxy_map, domain_map_array,
                               app_map_array, config_file)
 
-    (changed, config_valid) = compareWriteAndReloadConfig(generated_config, config_file,
-                                                          domain_map_array, app_map_array, haproxy_map)
+    (changed, config_valid) = compareWriteAndReloadConfig(
+        generated_config, config_file, domain_map_array, app_map_array,
+        haproxy_map)
 
     if changed and not config_valid:
-        apps = make_config_valid_and_regenerate(marathon, groups, bind_http_https, ssl_certs,
-                                         templater, haproxy_map, domain_map_array,
-                                         app_map_array, config_file)
+        apps = make_config_valid_and_regenerate(
+            marathon, groups, bind_http_https, ssl_certs, templater,
+            haproxy_map, domain_map_array, app_map_array, config_file)
 
     return apps
 
+
 # Build up a valid configuration by adding one app at a time and checking
 # for valid config file after each app
-def make_config_valid_and_regenerate(marathon, groups, bind_http_https, ssl_certs,
-                                     templater, haproxy_map, domain_map_array,
-                                     app_map_array, config_file):
+def make_config_valid_and_regenerate(marathon, groups, bind_http_https,
+                                     ssl_certs, templater, haproxy_map,
+                                     domain_map_array, app_map_array,
+                                     config_file):
     try:
         start_time = time.time()
-        
         valid_marathon_apps = []
         marathon_apps = marathon.list()
         apps = []
         excluded_ids = []
 
         for app in marathon_apps:
-            
             valid_marathon_apps.append(app)
             apps = get_apps(marathon, valid_marathon_apps)
 
@@ -1555,11 +1555,14 @@ def make_config_valid_and_regenerate(marathon, groups, bind_http_https, ssl_cert
             generated_config = config(apps, groups, bind_http_https, ssl_certs,
                                       templater, haproxy_map, domain_map_array,
                                       app_map_array, config_file)
-            
+
             if not generateAndValidateConfig(generated_config, config_file,
-                                             domain_map_array, app_map_array, haproxy_map):
+                                             domain_map_array, app_map_array,
+                                             haproxy_map):
                 invalid_id = valid_marathon_apps[-1]["id"]
-                logger.warn("invalid configuration caused by app %s; it will be excluded", invalid_id)
+                logger.warn(
+                    "invalid configuration caused by app %s; "
+                    "it will be excluded", invalid_id)
                 excluded_ids.append(invalid_id)
                 del valid_marathon_apps[-1]
 
@@ -1567,14 +1570,19 @@ def make_config_valid_and_regenerate(marathon, groups, bind_http_https, ssl_cert
                     apps = []
 
         if len(valid_marathon_apps) > 0:
-            logger.debug("regentrating valid config which excludes the following apps: %s", excluded_ids)
-            compareWriteAndReloadConfig(generated_config, config_file,
-                                        domain_map_array, app_map_array, haproxy_map)
+            logger.debug("regentrating valid config which excludes the"
+                         "following apps: %s", excluded_ids)
+            compareWriteAndReloadConfig(generated_config,
+                                        config_file,
+                                        domain_map_array,
+                                        app_map_array, haproxy_map)
         else:
-            logger.error("A valid config file could not be generated after excluding all apps! skipping reload")
-        
-        logger.debug("regenerating while excluding invalid tasks finished, took %s seconds",
-                        time.time() - start_time)   
+            logger.error("A valid config file could not be generated after"
+                         "excluding all apps! skipping reload")
+
+        logger.debug("regenerating while excluding invalid tasks finished, "
+                     "took %s seconds",
+                     time.time() - start_time)
 
         return apps
 
@@ -1900,7 +1908,7 @@ if __name__ == '__main__':
             currentWaitSeconds = random.random() * waitSeconds
             try:
                 process_sse_events(marathon, processor)
-            except pycurl.error, e:
+            except pycurl.error as e:
                 errno, e_msg = e.args
                 # Error number 28:
                 # 'Operation too slow. Less than 1 bytes/sec transferred
@@ -1915,7 +1923,8 @@ if __name__ == '__main__':
                     raise
             except:
                 logger.exception("Caught exception")
-                logger.error("Reconnecting in {}s...".format(currentWaitSeconds))
+                logger.error("Reconnecting in {}s...".format(
+                    currentWaitSeconds))
 
             # Immediately reconnect
             if currentWaitSeconds == 0:

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1913,8 +1913,10 @@ if __name__ == '__main__':
                 # Error number 28:
                 # 'Operation too slow. Less than 1 bytes/sec transferred
                 #  the last 300 seconds'
-                # In this case we should immediately reconnect
-                # without a backoff.
+                # This happens when there is no activity on the marathon
+                # event stream for the last 5 minutes. In this case we
+                # should immediately in case the connection to marathon
+                # died silently so that we miss as few events as possible.
                 if errno == 28:
                     m = 'Possible timeout detected: {}, reconnecting now...'
                     logger.info(m.format(e_msg))

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1589,7 +1589,7 @@ def make_config_valid_and_regenerate(marathon, groups, bind_http_https,
     except requests.exceptions.ConnectionError as e:
         logger.error("Connection error({0}): {1}".format(
             e.errno, e.strerror))
-    except:
+    except Exception:
         logger.exception("Unexpected error!")
 
 
@@ -1668,7 +1668,7 @@ class MarathonEventProcessor(object):
         except requests.exceptions.ConnectionError as e:
             logger.error("Connection error({0}): {1}".format(
                 e.errno, e.strerror))
-        except:
+        except Exception:
             logger.exception("Unexpected error!")
 
     def do_reload(self):
@@ -1677,7 +1677,7 @@ class MarathonEventProcessor(object):
             logger.debug("attempting to reload existing config...")
             if validateConfig(self.__config_file):
                 reloadConfig()
-        except:
+        except Exception:
             logger.exception("Unexpected error!")
 
     def stop(self):
@@ -1819,7 +1819,7 @@ def process_sse_events(marathon, processor):
                         processor.handle_event(data)
                 else:
                     logger.info("skipping empty message")
-            except:
+            except Exception:
                 print(event.data)
                 print("Unexpected error:", sys.exc_info()[0])
                 traceback.print_stack()
@@ -1921,7 +1921,7 @@ if __name__ == '__main__':
                     currentWaitSeconds = 0
                 else:
                     raise
-            except:
+            except Exception:
                 logger.exception("Caught exception")
                 logger.error("Reconnecting in {}s...".format(
                     currentWaitSeconds))

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1920,7 +1920,9 @@ if __name__ == '__main__':
                     logger.info(m.format(e_msg))
                     currentWaitSeconds = 0
                 else:
-                    raise
+                    logger.exception("Caught exception")
+                    logger.error("Reconnecting in {}s...".format(
+                        currentWaitSeconds))
             except Exception:
                 logger.exception("Caught exception")
                 logger.error("Reconnecting in {}s...".format(

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1915,8 +1915,9 @@ if __name__ == '__main__':
                 #  the last 300 seconds'
                 # This happens when there is no activity on the marathon
                 # event stream for the last 5 minutes. In this case we
-                # should immediately in case the connection to marathon
-                # died silently so that we miss as few events as possible.
+                # should immediately reconnect in case the connection to
+                # marathon died silently so that we miss as few events as
+                # possible.
                 if errno == 28:
                     m = 'Possible timeout detected: {}, reconnecting now...'
                     logger.info(m.format(e_msg))

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1929,7 +1929,9 @@ if __name__ == '__main__':
                 logger.exception("Caught exception")
                 logger.error("Reconnecting in {}s...".format(
                     currentWaitSeconds))
-
+            # We must close the connection because we are calling
+            # get_event_stream on the next loop
+            stream.curl.close()
             if currentWaitSeconds > 0:
                 # Increase the next waitSeconds by the backoff factor
                 waitSeconds = backoffFactor * waitSeconds
@@ -1940,9 +1942,6 @@ if __name__ == '__main__':
                 if (time.time() - stream_started) > waitResetSeconds:
                     waitSeconds = 3
                 time.sleep(currentWaitSeconds)
-            # We must close the connection because we are calling
-            # get_event_stream on the next loop
-            stream.curl.close()
         processor.stop()
     else:
         # Generate base config


### PR DESCRIPTION
Addresses the problem of continuously throwing the following error:

```
2017-11-03 05:31:36,031 marathon_lb: Caught exception
Traceback (most recent call last):
File "/marathon-lb/marathon_lb.py", line 1799, in <module>
process_sse_events(marathon, processor)
File "/marathon-lb/marathon_lb.py", line 1700, in process_sse_events
for event in events:
File "/marathon-lb/marathon_lb.py", line 239, in get_event_stream
for line in resp.iter_lines():
File "/marathon-lb/utils.py", line 241, in _split_lines_from_chunks
for chunk in chunks:
File "/marathon-lb/utils.py", line 226, in _iter_chunks
self._check_curl_errors()
File "/marathon-lb/utils.py", line 230, in _check_curl_errors
raise pycurl.error(*f[1:])
pycurl.error: (28, 'Operation too slow. Less than 1 bytes/sec transferred the last 300 seconds')
2017-11-03 05:31:36,043 marathon_lb: Reconnecting in 4.5s...
```

The fix is to reconnect immediately when this error is encountered. The changes also include a slight fix to the logging - it was not accurately displaying the number of seconds to wait previously.

After the fix, the log output for the above case is:

```
017-12-06 23:55:18,539 marathon_lb: Possible timeout detected: Operation too slow. Less than 1 bytes/sec transferred the last 300 seconds, reconnecting now...
```