### PR TITLE
enable strictmode

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -104,7 +104,7 @@ class MarathonService(object):
         self.authUser = None
         self.authPasswd = None
         self.sticky = False
-        self.enabled = not strictMode
+        self.enabled = True
         self.redirectHttpToHttps = False
         self.useHsts = False
         self.sslCert = None


### PR DESCRIPTION
Currently DCOS document says that strict mode is compatible with marathon-lb.