### PR TITLE
fix: undefined HAPROXY_DEPLOYMENT_TARGET_INSTANCES

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1352,8 +1352,11 @@ def get_apps(marathon, apps=[]):
                         old = new
                         new = temp
 
-            target_instances = \
-                int(new['labels']['HAPROXY_DEPLOYMENT_TARGET_INSTANCES'])
+                target_instances = \
+                    int(new['labels']['HAPROXY_DEPLOYMENT_TARGET_INSTANCES'])
+
+            else:
+                target_instances = 0
 
             # Mark N tasks from old app as draining, where N is the
             # number of instances in the new app.  Sort the old tasks so that

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1356,7 +1356,7 @@ def get_apps(marathon, apps=[]):
                     int(new['labels']['HAPROXY_DEPLOYMENT_TARGET_INSTANCES'])
 
             else:
-                target_instances = 0
+                target_instances = 1
 
             # Mark N tasks from old app as draining, where N is the
             # number of instances in the new app.  Sort the old tasks so that


### PR DESCRIPTION
if service doesn't have label HAPROXY_DEPLOYMENT_TARGET_INSTANCES it will throw an error because an undefined value of new['labels']['HAPROXY_DEPLOYMENT_TARGET_INSTANCES']

logs:
```
2018-01-04 09:41:08,631 marathon_lb: received event of type instance_changed_event
2018-01-04 09:41:12,781 marathon_lb: received event of type status_update_event
2018-01-04 09:41:12,782 marathon_lb: received event of type instance_changed_event
2018-01-04 09:41:12,782 marathon_lb: fetching apps
2018-01-04 09:41:12,818 marathon_lb: GET http://marathon.mesos:8080/v2/apps?embed=apps.tasks
2018-01-04 09:41:12,826 marathon_lb: got apps ['/shipping-rules', '/crm', '/logger', '/notifications-http', '/autoscaler', '/discount-rules', '/notifications-consumer', '/wishlist', '/memsql', '/marathon-lb', '/products', '/orders', '/siege']
2018-01-04 09:41:12,827 marathon_lb: Unexpected error!
Traceback (most recent call last):
  File "/marathon-lb/marathon_lb.py", line 1550, in do_reset
    self.__apps = get_apps(self.__marathon)
  File "/marathon-lb/marathon_lb.py", line 1317, in get_apps
    int(new['labels']['HAPROXY_DEPLOYMENT_TARGET_INSTANCES'])
KeyError: 'HAPROXY_DEPLOYMENT_TARGET_INSTANCES'
```

probably, it's happening because of variable `target_instances` always get value from label `HAPROXY_DEPLOYMENT_TARGET_INSTANCES` which is possible empty or undefined.

the proposed solution is by adding an extra check if label `HAPROXY_DEPLOYMENT_TARGET_INSTANCES` is empty or undefined, then the value of variable `target_instances` will set to 1

pls advice & cmiiw


  