### PR TITLE
Use lightweight Marathon events.

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -226,7 +226,7 @@ class Marathon(object):
         return self.api_req('GET', ['tasks'])["tasks"]
 
     def get_event_stream(self):
-        url = self.host + "/v2/events"
+        url = self.host + "/v2/events?plan-format=light"
         return CurlHttpEventStream(url, self.__auth, self.__verify)
 
     def iter_events(self, stream):


### PR DESCRIPTION
We introduced lightweight events with MARATHON_EE-1673. These do not
include the complete groups and make the events much smaller. This
should not only ease the consumption but also the workload for
Marathon.

This patch should close MARATHON-8036.