### PR TITLE
Filter events on server side, in order to decrease load on Marathon

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -226,7 +226,7 @@ class Marathon(object):
         return self.api_req('GET', ['tasks'])["tasks"]
 
     def get_event_stream(self):
-        url = self.host + "/v2/events?" + \
+        url = self.host + "/v2/events?plan-format=light&" + \
               "event_type=status_update_event&" + \
               "event_type=health_status_changed_event&" + \
               "event_type=api_post_event"

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -226,7 +226,10 @@ class Marathon(object):
         return self.api_req('GET', ['tasks'])["tasks"]
 
     def get_event_stream(self):
-        url = self.host + "/v2/events"
+        url = self.host + "/v2/events?" + \
+              "event_type=status_update_event&" + \
+              "event_type=health_status_changed_event&" + \
+              "event_type=api_post_event"
         return CurlHttpEventStream(url, self.__auth, self.__verify)
 
     def iter_events(self, stream):


### PR DESCRIPTION
We introduced lightweight events with MARATHON_EE-1673. These do not
include the complete groups and make the events much smaller. This
should not only ease the consumption but also the workload for
Marathon. Furthermore Marathon LB should only request the events
it actually needs.

This patch should close MARATHON-8036 and MARATHON-8047.