### PR TITLE
Use multiple keyservers for gpg verify of tini during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,22 @@ ENV TINI_VERSION=v0.13.2 \
     TINI_GPG_KEY=595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
 RUN set -x \
     && apt-get update && apt-get install -y --no-install-recommends dirmngr gpg wget \
-        && rm -rf /var/lib/apt/lists/* \
-    && wget -O tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-amd64" \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-amd64" \
     && wget -O tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-amd64.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY" \
+    || gpg --keyserver pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY" \
+    || gpg --keyserver keyserver.pgp.com --recv-keys "$TINI_GPG_KEY" \
+    || gpg --keyserver pgp.mit.edu --recv-keys "$TINI_GPG_KEY" \
     && gpg --batch --verify tini.asc tini \
     && rm -rf "$GNUPGHOME" tini.asc \
     && mv tini /usr/bin/tini \
     && chmod +x /usr/bin/tini \
-    && tini -- true \
-    && apt-get purge -y --auto-remove dirmngr gpg wget
+    && tini -- true
+
+RUN apt-get purge -y --auto-remove dirmngr gpg wget
 
 
 ENV HAPROXY_MAJOR=1.7 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV TINI_VERSION=v0.13.2 \
     TINI_GPG_KEY=595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
+
 RUN set -x \
     && apt-get update && apt-get install -y --no-install-recommends dirmngr gpg wget \
-        && rm -rf /var/lib/apt/lists/*
-
-RUN wget -O tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-amd64" \
+        && rm -rf /var/lib/apt/lists/* \
+    && wget -O tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-amd64" \
     && wget -O tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-amd64.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$TINI_GPG_KEY" \
@@ -33,9 +33,8 @@ RUN wget -O tini "https://github.com/krallin/tini/releases/download/$TINI_VERSIO
     && rm -rf "$GNUPGHOME" tini.asc \
     && mv tini /usr/bin/tini \
     && chmod +x /usr/bin/tini \
-    && tini -- true
-
-RUN apt-get purge -y --auto-remove dirmngr gpg wget
+    && tini -- true \
+    && apt-get purge -y --auto-remove dirmngr gpg wget
 
 
 ENV HAPROXY_MAJOR=1.7 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV TINI_VERSION=v0.13.2 \
     TINI_GPG_KEY=595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
 
+# Multiple gpg --recv-keys are intended to help with flakiness of key servers.
 RUN set -x \
     && apt-get update && apt-get install -y --no-install-recommends dirmngr gpg wget \
         && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Cherry pick of 8534066a1293d33e6d52c39f2d6324c40a03394c

Makes two changes:
* Split the tini retrieve, verify, and install into a separate Dockerfile RUN command.
* Use multiple keyservers.