### PR TITLE
disable configuration cleanup on failed validation (#554)

### DIFF
--- a/Longhelp.md
+++ b/Longhelp.md
@@ -24,7 +24,8 @@ usage: marathon_lb.py [-h] [--longhelp] [--marathon MARATHON [MARATHON ...]]
                       [--sse] [--health-check]
                       [--lru-cache-capacity LRU_CACHE_CAPACITY]
                       [--haproxy-map] [--dont-bind-http-https]
-                      [--ssl-certs SSL_CERTS] [--skip-validation] [--dry]
+                      [--ssl-certs SSL_CERTS] [--skip-validation]
+                      [--skip-config-cleanup] [--dry]
                       [--min-serv-port-ip-per-task MIN_SERV_PORT_IP_PER_TASK]
                       [--max-serv-port-ip-per-task MAX_SERV_PORT_IP_PER_TASK]
                       [--syslog-socket SYSLOG_SOCKET]
@@ -58,7 +59,7 @@ optional arguments:
                         every --reload-interval seconds. Set to 0 to disable
                         or -1 for infinite retries. (default: 10)
   --reload-interval RELOAD_INTERVAL
-                        Wait this number of seconds betwee nreload retries.
+                        Wait this number of seconds between reload retries.
                         (default: 10)
   --strict-mode         If set, backends are only advertised if
                         HAPROXY_{n}_ENABLED=true. Strict mode will be enabled
@@ -82,6 +83,9 @@ optional arguments:
                         /etc/ssl/site1.co.pem,/etc/ssl/site2.co.pem (default:
                         /etc/ssl/cert.pem)
   --skip-validation     Skip haproxy config file validation (default: False)
+  --skip-config-cleanup
+                        If one app fails, don't try to make configuration
+                        valid by removing apps one by one (default: False)
   --dry, -d             Only print configuration to console (default: False)
   --min-serv-port-ip-per-task MIN_SERV_PORT_IP_PER_TASK
                         Minimum port number to use when auto-assigning service

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1311,6 +1311,7 @@ def get_apps(marathon, apps=[]):
     # to a deployment group.
     processed_apps = []
     deployment_groups = {}
+
     for app in apps:
         deployment_group = None
         if 'HAPROXY_DEPLOYMENT_GROUP' in app['labels']:
@@ -1531,7 +1532,7 @@ def regenerate_config(marathon, config_file, groups, bind_http_https,
         generated_config, config_file, domain_map_array, app_map_array,
         haproxy_map)
 
-    if changed and not config_valid:
+    if changed and not config_valid and not args.skip_config_cleanup:
         apps = make_config_valid_and_regenerate(
             marathon, groups, bind_http_https, ssl_certs, templater,
             haproxy_map, domain_map_array, app_map_array, config_file)
@@ -1802,6 +1803,10 @@ def get_arg_parser():
                         default="/etc/ssl/cert.pem")
     parser.add_argument("--skip-validation",
                         help="Skip haproxy config file validation",
+                        action="store_true")
+    parser.add_argument("--skip-config-cleanup",
+                        help="If one app fails, don't try to make configuration "
+                        "valid by removing apps one by one",
                         action="store_true")
     parser.add_argument("--dry", "-d",
                         help="Only print configuration to console",


### PR DESCRIPTION
This change set introduces an optional command line flag, which allows to skip the new app by app validation/cleanup in favour of the old behaviour:

A broken setup causes no reload of the haproxy.cfg. The old configuration is still usable. The haproxy.cfg is checked once entirely for configuration problems.

Unfortunately for the setup described in #554  the new app-by-app cleanup meant, that some applications would not be accessible anymore after removing them, depending on the order they are delivered by marathon. This currently prevents us from upgrading marathon-lb.

