### PR TITLE
Fix bug in config validation and reduce marathon calls

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -8,6 +8,7 @@ else
   PIPCMD='pip3'
 fi
 
+$PIPCMD install --upgrade pip setuptools
 $PIPCMD install -r requirements-dev.txt
 
 PYTHONPATH=. coverage run "$(which nosetests)"

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1170,7 +1170,7 @@ def truncateMapFileIfExists(map_file):
 
 
 def generateAndValidateTempConfig(config, config_file, domain_map_array,
-                              app_map_array, haproxy_map):
+                                  app_map_array, haproxy_map):
     temp_config_file = "%s.tmp" % config_file
     domain_map_file = os.path.join(os.path.dirname(temp_config_file),
                                    "domain2backend.map.tmp")
@@ -1542,10 +1542,10 @@ def regenerate_config(marathon, config_file, groups, bind_http_https,
 
 # Build up a valid configuration by adding one app at a time and checking
 # for valid config file after each app
-def make_config_valid_and_regenerate(marathon, raw_apps, groups, bind_http_https,
-                                     ssl_certs, templater, haproxy_map,
-                                     domain_map_array, app_map_array,
-                                     config_file):
+def make_config_valid_and_regenerate(marathon, raw_apps, groups,
+                                     bind_http_https, ssl_certs, templater,
+                                     haproxy_map, domain_map_array,
+                                     app_map_array, config_file):
     try:
         start_time = time.time()
         apps = []


### PR DESCRIPTION
Config validation was not working as expected. After regenerating config while removing invalid apps, the generated haproxy.cfg remained the same as pre-validation.

This primarily happened because it was writing a haproxy.cfg meant only for validation test to the actual live haproxy.cfg path on disk. Later when the logic to check for changes that should trigger a reload, it detected no change because the validation test file was in the same spot.

Another problem was that if the last app in the list happened to be the bad one, the bad config would actually make it into the final config.

This PR also reduces the necessary N calls to list apps where N=total number of apps in marathon which can cause significant stress on large deployments.