### PR TITLE
Work around python3 > dh-python > dkpg-dev > make dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 \
         runit \
         gnupg-agent \
-	socat \
+        socat \
+        make \
     && rm -rf /var/lib/apt/lists/*
 
 ENV TINI_VERSION=v0.13.2 \
@@ -53,7 +54,6 @@ RUN set -x \
         liblua5.3-dev \
         libpcre3-dev \
         libssl-dev \
-        make \
         python3-dev \
         python3-pip \
         python3-setuptools \


### PR DESCRIPTION
Somewhere upstream, a dependency was introduced such that:

`python3` depends on `dh-python`
`dh-python` depends on `dpkg-dev`
`dpkg-dev` depends on `make`

So uninstalling make (via `apt-get purge -y --auto-remove`) removes python3, and everything breaks.

This turns `make` from a build dependency to a runtime dependency - probably not ideal, but it's the easiest workaround for now.  We'll want to look at discussing how to change/prevent this in the future.