### PR TITLE
Append reload command only if it doesn't exist already

### DIFF
--- a/run
+++ b/run
@@ -118,7 +118,7 @@ for arg in "$@"; do
     ARGS="$ARGS $escaped"
 done
 
-echo "sv reload ${HAPROXY_SERVICE}" >> /marathon-lb/reload_haproxy.sh
+grep -q -F -w "sv reload ${HAPROXY_SERVICE}" /marathon-lb/reload_haproxy.sh || echo "sv reload ${HAPROXY_SERVICE}" >> /marathon-lb/reload_haproxy.sh
 
 cat > $LB_SERVICE/run << EOF
 #!/bin/sh


### PR DESCRIPTION
This PR includes a check for the reload command before appending it to the reload file. Without this, the `reload_haproxy.sh` file is slowly filled with multiple `sv reload ...` commands.

CC: @justinrlee @drewkerrigan @jdef 