### PR TITLE
Adding MLB Integration Tests to CI

### DIFF
--- a/ci/backends/docker_bridge.json
+++ b/ci/backends/docker_bridge.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-docker-bridge",
+  "user":"root",
   "cmd": "echo 'nginx-docker-bridge' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "container": {
     "portMappings": [
@@ -20,7 +21,8 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10100",
-    "HAPROXY_0_VHOST": "nginx-docker-bridge.test"
+    "HAPROXY_0_VHOST": "nginx-docker-bridge.test",
+    "HAPROXY_0_ENABLED": "true"
   },
   "mem": 32,
   "networks": [

--- a/ci/backends/docker_bridge.json
+++ b/ci/backends/docker_bridge.json
@@ -1,0 +1,32 @@
+{
+  "id": "/nginx-docker-bridge",
+  "cmd": "echo 'nginx-docker-bridge' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "nginx"
+    }
+  },
+  "cpus": 0.1,
+  "instances": 4,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10100",
+    "HAPROXY_0_VHOST": "nginx-docker-bridge.test"
+  },
+  "mem": 32,
+  "networks": [
+    {
+      "mode": "container/bridge"
+    }
+  ],
+  "requirePorts": false
+}

--- a/ci/backends/docker_host.json
+++ b/ci/backends/docker_host.json
@@ -1,0 +1,31 @@
+{
+  "id": "/nginx-docker-host",
+  "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-docker-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "nginx",
+      "network": "HOST"
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "mem": 32,
+  "requirePorts": false,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10300",
+    "HAPROXY_0_VHOST": "nginx-docker-host.test"
+  },
+  "healthChecks": [],
+  "fetch": [],
+  "constraints": [],
+  "portDefinitions": [
+    {
+      "protocol": "tcp",
+      "port": 0
+    }
+  ]
+}

--- a/ci/backends/docker_host.json
+++ b/ci/backends/docker_host.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-docker-host",
+  "user":"root",
   "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-docker-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "container": {
     "type": "DOCKER",
@@ -17,7 +18,8 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10300",
-    "HAPROXY_0_VHOST": "nginx-docker-host.test"
+    "HAPROXY_0_VHOST": "nginx-docker-host.test",
+    "HAPROXY_0_ENABLED": "true"
   },
   "healthChecks": [],
   "fetch": [],

--- a/ci/backends/docker_ippc.json
+++ b/ci/backends/docker_ippc.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-docker-ippc",
+  "user":"root",
   "cmd": "echo 'nginx-docker-ippc' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "cpus": 0.1,
   "mem": 32,
@@ -22,7 +23,8 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10200",
-    "HAPROXY_0_VHOST": "nginx-docker-ippc.test"
+    "HAPROXY_0_VHOST": "nginx-docker-ippc.test",
+    "HAPROXY_0_ENABLED": "true"
   },
   "ipAddress": {
     "groups": [],

--- a/ci/backends/docker_ippc.json
+++ b/ci/backends/docker_ippc.json
@@ -1,0 +1,31 @@
+{
+  "id": "/nginx-docker-ippc",
+  "cmd": "echo 'nginx-docker-ippc' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "cpus": 0.1,
+  "mem": 32,
+  "disk": 0,
+  "instances": 4,
+  "container": {
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "nginx",
+      "parameters": []
+    },
+    "portMappings": [
+      {
+        "containerPort": 80
+      }
+    ]
+  },
+  "requirePorts": false,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10200",
+    "HAPROXY_0_VHOST": "nginx-docker-ippc.test"
+  },
+  "ipAddress": {
+    "groups": [],
+    "networkName": "dcos"
+  }
+}

--- a/ci/backends/ucr_bridge.json
+++ b/ci/backends/ucr_bridge.json
@@ -1,0 +1,33 @@
+{
+  "id": "/nginx-ucr-bridge",
+  "cmd": "echo 'nginx-ucr-bridge' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "type": "MESOS",
+    "volumes": [],
+    "docker": {
+      "image": "nginx"
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "mem": 32,
+  "requirePorts": false,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10500",
+    "HAPROXY_0_VHOST": "nginx-ucr-bridge.test"
+  },
+  "networks": [
+    {
+      "mode": "container/bridge"
+    }
+  ]
+}

--- a/ci/backends/ucr_bridge.json
+++ b/ci/backends/ucr_bridge.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-ucr-bridge",
+  "user":"root",
   "cmd": "echo 'nginx-ucr-bridge' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "container": {
     "portMappings": [
@@ -23,7 +24,8 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10500",
-    "HAPROXY_0_VHOST": "nginx-ucr-bridge.test"
+    "HAPROXY_0_VHOST": "nginx-ucr-bridge.test",
+    "HAPROXY_0_ENABLED": "true"
   },
   "networks": [
     {

--- a/ci/backends/ucr_host.json
+++ b/ci/backends/ucr_host.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-ucr-host",
+  "user":"root",
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
   "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-ucr-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
@@ -18,7 +19,8 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10400",
-    "HAPROXY_0_VHOST": "nginx-ucr-host.test"
+    "HAPROXY_0_VHOST": "nginx-ucr-host.test",
+    "HAPROXY_0_ENABLED": "true"
   },
   "maxLaunchDelaySeconds": 3600,
   "mem": 32,

--- a/ci/backends/ucr_host.json
+++ b/ci/backends/ucr_host.json
@@ -1,0 +1,37 @@
+{
+  "id": "/nginx-ucr-host",
+  "backoffFactor": 1.15,
+  "backoffSeconds": 1,
+  "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-ucr-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "type": "MESOS",
+    "volumes": [],
+    "docker": {
+      "image": "nginx",
+      "forcePullImage": false,
+      "parameters": []
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10400",
+    "HAPROXY_0_VHOST": "nginx-ucr-host.test"
+  },
+  "maxLaunchDelaySeconds": 3600,
+  "mem": 32,
+  "gpus": 0,
+  "networks": [
+    {
+      "mode": "host"
+    }
+  ],
+  "portDefinitions": [
+    {
+      "protocol": "tcp",
+      "port": 10003
+    }
+  ]
+}

--- a/ci/backends/ucr_ippc.json
+++ b/ci/backends/ucr_ippc.json
@@ -1,0 +1,32 @@
+{
+  "id": "/nginx-ucr-ippc",
+  "backoffFactor": 1.15,
+  "backoffSeconds": 1,
+  "cmd": "echo 'nginx-ucr-ippc' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "type": "MESOS",
+    "volumes": [],
+    "docker": {
+      "image": "nginx",
+      "forcePullImage": false,
+      "parameters": []
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10600",
+    "HAPROXY_0_VHOST": "nginx-ucr-ippc.test",
+    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  server {serverName} {host_ipv4}:80 {cookieOptions}{healthCheckOptions}{otherOptions}\n"
+  },
+  "mem": 32,
+  "gpus": 0,
+  "networks": [
+    {
+      "name": "dcos",
+      "mode": "container"
+    }
+  ]
+}

--- a/ci/backends/ucr_ippc.json
+++ b/ci/backends/ucr_ippc.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-ucr-ippc",
+  "user":"root",
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
   "cmd": "echo 'nginx-ucr-ippc' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
@@ -19,7 +20,8 @@
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10600",
     "HAPROXY_0_VHOST": "nginx-ucr-ippc.test",
-    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  server {serverName} {host_ipv4}:80 {cookieOptions}{healthCheckOptions}{otherOptions}\n"
+    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  server {serverName} {host_ipv4}:80 {cookieOptions}{healthCheckOptions}{otherOptions}\n",
+    "HAPROXY_0_ENABLED": "true"
   },
   "mem": 32,
   "gpus": 0,

--- a/ci/backends_1.9/docker_bridge.json
+++ b/ci/backends_1.9/docker_bridge.json
@@ -1,0 +1,41 @@
+{
+  "id": "/nginx-docker-bridge",
+  "cmd": "echo 'nginx-docker-bridge' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "nginx",
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "mem": 32,
+  "networks": [
+    {
+      "mode": "container/bridge"
+    }
+  ],
+  "requirePorts": false,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10100",
+    "HAPROXY_0_VHOST": "nginx-docker-bridge.test"
+  }
+}

--- a/ci/backends_1.9/docker_bridge.json
+++ b/ci/backends_1.9/docker_bridge.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-docker-bridge",
+  "user":"root",
   "cmd": "echo 'nginx-docker-bridge' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "container": {
     "portMappings": [
@@ -36,6 +37,7 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10100",
-    "HAPROXY_0_VHOST": "nginx-docker-bridge.test"
+    "HAPROXY_0_VHOST": "nginx-docker-bridge.test",
+    "HAPROXY_0_ENABLED": "true"
   }
 }

--- a/ci/backends_1.9/docker_host.json
+++ b/ci/backends_1.9/docker_host.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-docker-host",
+  "user":"root",
   "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-docker-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "container": {
     "portMappings": [
@@ -29,7 +30,8 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10300",
-    "HAPROXY_0_VHOST": "nginx-docker-host.test"
+    "HAPROXY_0_VHOST": "nginx-docker-host.test",
+    "HAPROXY_0_ENABLED": "true"
   },
   "portDefinitions": [
     {

--- a/ci/backends_1.9/docker_host.json
+++ b/ci/backends_1.9/docker_host.json
@@ -1,0 +1,40 @@
+{
+  "id": "/nginx-docker-host",
+  "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-docker-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "nginx",
+      "network": "HOST"
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "mem": 32,
+  "networks": [
+    {
+      "mode": "container/bridge"
+    }
+  ],
+  "requirePorts": false,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10300",
+    "HAPROXY_0_VHOST": "nginx-docker-host.test"
+  },
+  "portDefinitions": [
+    {
+      "protocol": "tcp",
+      "port": 0
+    }
+  ]
+}

--- a/ci/backends_1.9/docker_ippc.json
+++ b/ci/backends_1.9/docker_ippc.json
@@ -1,0 +1,45 @@
+{
+  "id": "/nginx-docker-ippc",
+  "cmd": "echo 'nginx-docker-ippc' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "nginx",
+      "network": "USER",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "mem": 32,
+  "networks": [
+    {
+      "mode": "container/bridge"
+    }
+  ],
+  "requirePorts": false,
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10200",
+    "HAPROXY_0_VHOST": "nginx-docker-ippc.test"
+  },
+  "ipAddress": {
+    "groups": [],
+    "networkName": "dcos"
+  }
+}

--- a/ci/backends_1.9/docker_ippc.json
+++ b/ci/backends_1.9/docker_ippc.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-docker-ippc",
+  "user":"root",
   "cmd": "echo 'nginx-docker-ippc' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "container": {
     "portMappings": [
@@ -36,7 +37,8 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10200",
-    "HAPROXY_0_VHOST": "nginx-docker-ippc.test"
+    "HAPROXY_0_VHOST": "nginx-docker-ippc.test",
+    "HAPROXY_0_ENABLED": "true"
   },
   "ipAddress": {
     "groups": [],

--- a/ci/backends_1.9/ucr_host.json
+++ b/ci/backends_1.9/ucr_host.json
@@ -1,0 +1,39 @@
+{
+  "id": "/nginx-ucr-host",
+  "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-ucr-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
+  "container": {
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "type": "MESOS",
+    "volumes": [],
+    "docker": {
+      "image": "nginx"
+    }
+  },
+  "cpus": 0.1,
+  "disk": 0,
+  "instances": 4,
+  "mem": 32,
+  "networks": [
+    {
+      "mode": "container/bridge"
+    }
+  ],
+  "requirePorts": false,
+  "portDefinitions": [
+    {
+      "protocol": "tcp",
+      "port": 0
+    }
+  ],
+  "labels": {
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PORT": "10400",
+    "HAPROXY_0_VHOST": "nginx-ucr-host.test"
+  }
+}

--- a/ci/backends_1.9/ucr_host.json
+++ b/ci/backends_1.9/ucr_host.json
@@ -1,5 +1,6 @@
 {
   "id": "/nginx-ucr-host",
+  "user":"root",
   "cmd": "sed -i \"s/80/${PORT0}/\" /etc/nginx/conf.d/default.conf; echo 'nginx-ucr-host' > /usr/share/nginx/html/index.html; nginx -g 'daemon off;'",
   "container": {
     "portMappings": [
@@ -34,6 +35,7 @@
   "labels": {
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_PORT": "10400",
-    "HAPROXY_0_VHOST": "nginx-ucr-host.test"
+    "HAPROXY_0_VHOST": "nginx-ucr-host.test",
+    "HAPROXY_0_ENABLED": "true"
   }
 }

--- a/ci/ci-integration.sh
+++ b/ci/ci-integration.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Do not fail upon error
-set +eo pipefail
+set -euxo pipefail
 
 export CLUSTER_URL=${CLUSTER_URL:="uninitialized"}
 export PUBLIC_AGENT_IP=${PUBLIC_AGENT_IP:="uninitialized"}
@@ -219,6 +219,8 @@ enterprise_authentication() {
         done
 
         echo "Authenticating"
+        # **
+        dcos config set core.ssl_verify false
         dcos cluster setup --no-check --username=$DCOS_USERNAME --password=$DCOS_PASSWORD $CLUSTER_URL
 
         echo "Verifying cluster authentication:"

--- a/ci/ci-integration.sh
+++ b/ci/ci-integration.sh
@@ -3,8 +3,6 @@
 # Do not fail upon error
 set +eo pipefail
 
-export LC_ALL="en_US.UTF-8"
-
 export CLUSTER_URL=${CLUSTER_URL:="uninitialized"}
 export PUBLIC_AGENT_IP=${PUBLIC_AGENT_IP:="uninitialized"}
 

--- a/ci/ci-integration.sh
+++ b/ci/ci-integration.sh
@@ -1,0 +1,356 @@
+#!/bin/bash
+
+export LC_ALL="en_US.UTF-8"
+
+# Do not fail upon error
+set +eo pipefail
+
+export CLUSTER_URL=${CLUSTER_URL:="uninitialized"}
+export PUBLIC_AGENT_IP=${PUBLIC_AGENT_IP:="uninitialized"}
+
+DCOS_USERNAME=${DCOS_USERNAME:="bootstrapuser"}
+DCOS_PASSWORD=${DCOS_PASSWORD:="deleteme"}
+
+GIT_SHA_10=$(echo $GIT_COMMIT | cut -c 1-10)
+
+DOCKER_IMAGE="mesosphere/marathon-lb-dev:$GIT_SHA_10"
+echo "DOCKER_IMAGE=$DOCKER_IMAGE"
+
+MLB_VERSION="dev-$GIT_SHA_10"
+echo "MLB_VERSION=$MLB_VERSION"
+
+WORKING_DIRECTORY=$(pwd)
+
+
+status_line() {
+    printf "\n### $1 ###\n\n"
+}
+
+
+random_string() {
+    num_chars=$1
+
+    # Use a subshell so that the `set` commands do not pollute the parent shell
+    (
+        set +e +o pipefail
+
+        # Warning: this will error out on linux if set -o pipefail and set -e
+        # LC_CTYPE=C is needed on macOS
+        random_id=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | fold -w "$num_chars" | head -n 1)
+        echo "$random_id"
+    )
+}
+
+
+cluster_ids() {
+    # dcos cluster command was added into the CLI starting in DC/OS 1.10
+    if [ "${DCOS_VERSION}" != '1.9' ]; then 
+        if ! dcos cluster list >/dev/null 2>&1; then
+            return
+        fi
+
+        dcos cluster list | tail -n +2 | tr -s ' ' | sed -e "s/^ *//" |  cut -d' ' -f2
+    fi
+}
+
+
+wrapped_dcos_launch() {
+    # Use a subshell so `cd` doesn't pollute the environment
+    (
+        cd "$WORKING_DIRECTORY"
+        ./dcos-launch $@
+    )
+}
+
+
+# Setting DC/OS template.
+dcos_template() {
+    if [ "${VARIANT}" == 'open' ]; then
+        template_url="http://s3.amazonaws.com/downloads.dcos.io/dcos/testing/${DCOS_VERSION}/cloudformation/single-master.cloudformation.json"
+    elif [ "${VARIANT}" == 'ee' ]; then
+        template_url="http://s3.amazonaws.com/downloads.mesosphere.io/dcos-enterprise-aws-advanced/testing/${DCOS_VERSION}/${SECURITY_MODE}/cloudformation/ee.single-master.cloudformation.json"
+    fi
+
+    echo "$template_url"
+}
+
+
+# Downloading CLI.
+download_cli() {
+    if [ "$(uname)" = "Linux" ]; then
+        local _cli_os="linux"
+    elif [ "$(uname)" = "Darwin" ]; then
+        local _cli_os="darwin"
+    fi
+
+    if [ "${DCOS_VERSION}" == 'master' ]; then
+        local cli_version="dcos-1.12"
+    else
+        local cli_version="dcos-${DCOS_VERSION}"
+    fi
+
+    mkdir bin
+    export PATH=$PATH:$(pwd)/bin
+
+    curl -O "https://downloads.dcos.io/binaries/cli/${_cli_os}/x86-64/${cli_version}/dcos"
+
+    mv "dcos" "bin/dcos"
+    chmod +x "bin/dcos"
+
+    dcos
+}
+
+
+# Launching cluster using dcos-launch.
+launch_cluster() {
+    status_line "Launching cluster."
+
+    if [ "$CLUSTER_URL" != "uninitialized" ]; then
+        echo "Using provided CLUSTER_URL as cluster: $CLUSTER_URL"
+        return
+    fi
+
+    wget 'https://downloads.dcos.io/dcos/testing/master/dcos-launch' && chmod +x dcos-launch
+
+    echo "CLUSTER_URL is empty/unset, launching new cluster."
+
+    random_id="$(random_string 10)"
+    dcos_template_url="$(dcos_template)"
+
+    echo "DC/OS Template:"
+    echo $dcos_template_url
+
+    envsubst <<EOF > config.yaml
+---
+launch_config_version: 1
+template_url: $dcos_template_url
+deployment_name: dcos-ci-test-marathon-lb-$random_id
+provider: aws
+aws_region: us-west-2
+aws_access_key_id: ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+ssh_user: core
+template_parameters:
+    KeyName: default
+    AdminLocation: 0.0.0.0/0
+    PublicSlaveInstanceCount: 1
+    SlaveInstanceCount: 1
+EOF
+    
+    # DefaultInstanceType parameter has not been backported into 1.9 CF templates.
+    # The templates actually hardcode in this parameter instead.
+    if [ "${DCOS_VERSION}" != '1.9' ]; then
+        echo "    DefaultInstanceType: m4.large" >> config.yaml
+    fi
+
+    if [ "${VARIANT}" == 'ee' ]; then
+        if [ "${DCOS_VERSION}" == '1.11' ] || [ "${DCOS_VERSION}" == 'master' ]; then
+            echo "    LicenseKey: ${DCOS_LICENSE}" >> config.yaml
+        fi
+    fi
+
+    time wrapped_dcos_launch create
+    time wrapped_dcos_launch wait
+    wrapped_dcos_launch describe
+
+    CLUSTER_URL=http://$(wrapped_dcos_launch describe | jq -r .masters[0].public_ip)
+    PUBLIC_AGENT_IP=$(wrapped_dcos_launch describe | jq -r .public_agents[0].public_ip)
+
+    echo "CLUSTER_URL=$CLUSTER_URL"
+    echo "PUBLIC_AGENT_IP=$PUBLIC_AGENT_IP"
+}
+
+
+# Setting up cluster.
+configure_cluster() {
+    status_line "Configuring cluster."
+
+    if [ "${VARIANT}" == 'open' ]; then
+        oss_authentication
+    else
+        enterprise_authentication
+    fi
+}
+
+
+oss_authentication() {
+    # Authentication is slightly different for DC/OS 1.9.
+    if [ "${DCOS_VERSION}" == '1.9' ]; then
+        status_line "Authenticating DC/OS OSS"
+        dcos config set core.dcos_url $CLUSTER_URL
+
+cat <<EOF | expect -
+spawn dcos auth login
+expect "Enter OpenID Connect ID Token:"
+send "$DCOS_OAUTH_TOKEN\n"
+expect eof
+EOF
+    else
+        echo "Removing old clusters."
+        for id in $(cluster_ids); do
+            echo "remove $id"
+            dcos cluster remove $id
+        done
+
+cat <<EOF | expect -
+spawn dcos cluster setup "$CLUSTER_URL"
+expect "Enter OpenID Connect ID Token:"
+send "$DCOS_OAUTH_TOKEN\n"
+expect eof
+EOF
+    fi
+
+echo "Verifying cluster authentication:"
+dcos config show
+}
+
+
+enterprise_authentication() {
+    # Authentication is slightly different for DC/OS 1.9.
+    if [ "${DCOS_VERSION}" == '1.9' ]; then
+        status_line "Authenticating DC/OS Enterprise"
+        dcos config set core.dcos_url $CLUSTER_URL
+        dcos auth login --username=$DCOS_USERNAME --password=$DCOS_PASSWORD
+    else
+        echo "Removing old clusters."
+        for id in $(cluster_ids); do
+            echo "remove $id"
+            dcos cluster remove $id
+        done
+
+        echo "Authenticating"
+        dcos cluster setup --no-check --username=$DCOS_USERNAME --password=$DCOS_PASSWORD $CLUSTER_URL
+
+        echo "Verifying cluster authentication:"
+        dcos cluster list
+    fi
+}
+
+
+# cd into MLB directory.
+change_into_mlb_dir() {
+    status_line "Changing into cloned MLB directory."
+    cd dcos-marathon-lb/
+}
+
+
+# Building docker image based on git SHA.
+docker_build() {
+    status_line "Building docker image."
+    docker build -t $DOCKER_IMAGE .
+}
+
+
+# Logging into Mesosphere docker account.
+docker_login() {
+    status_line "Logging into Mesosphere docker account."
+    docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}"
+}
+
+
+# Pushing docker image to mesosphere/marathon-lb-dev.
+docker_push() {
+    status_line "Pushing docker image."
+    docker push $DOCKER_IMAGE
+}
+
+
+# Launching MLB through docker image.
+launch_marathonlb() {
+    status_line "Launching Marathon-lb"
+
+    echo "Retrieving authentication token for cluster."
+    AUTH_TOKEN=$(dcos config show core.dcos_acs_token)
+
+    PAYLOAD="{\"packageName\": \"marathon-lb\"}"
+
+    RESPONSE="response.json"
+    JSON_TEMPLATE="template.json"
+    MLB_JSON="mlb_json.json"
+
+    CODE=$(curl -X POST -s -k -o $RESPONSE -H "Authorization: token=$AUTH_TOKEN" -w "%{http_code}" -H "Content-Type: application/vnd.dcos.package.render-request+json;charset=utf-8;version=v1" -H "Accept: application/vnd.dcos.package.render-response+json;charset=utf-8;version=v1" -d "$PAYLOAD" $CLUSTER_URL/package/render)
+
+    if [ "$CODE" -eq "200" ]; then
+        echo " "
+        cat $RESPONSE | jq -r ".marathonJson" > $JSON_TEMPLATE
+        cat $JSON_TEMPLATE | jq --arg DOCKER_IMAGE "$DOCKER_IMAGE"  '.container.docker.image=$DOCKER_IMAGE' | jq --arg MLB_VERSION "$MLB_VERSION" '.labels.DCOS_PACKAGE_VERSION=$MLB_VERSION' > $MLB_JSON
+        cat $MLB_JSON
+        echo " "
+    else
+        echo " "
+        echo "POST to package/render endpoint failed: $CODE"
+        delete_cluster
+        exit 1
+    fi
+
+    # Launch MLB app.
+    dcos marathon app add $MLB_JSON
+
+    # Sleeping to wait for MLB to deploy.
+    sleep 60s
+
+    # Verify that MLB deployed healthy.
+    check_marathonlb_health $AUTH_TOKEN
+}
+
+
+# Verify MLB launched healthy.
+check_marathonlb_health() {
+
+    RESPONSE_FILE="curl_response.json"
+    CODE=$(curl -X GET -s -k -o $RESPONSE_FILE -H "Authorization: token=$1" -w "%{http_code}" -H "Accept: application/json" $CLUSTER_URL/service/marathon/v2/apps/marathon-lb)
+    NUM_OF_HEALTHY_TASKS=($(jq -r '.app.tasksHealthy' $RESPONSE_FILE))
+    NUM_OF_INSTANCES=($(jq -r '.app.instances' $RESPONSE_FILE))
+
+    if [[ "$CODE" -eq "200" ]] && [[ "$NUM_OF_HEALTHY_TASKS" -eq "$NUM_OF_INSTANCES" ]]; then
+        echo " "
+        echo "Marathon-lb launched healthy."
+        echo " "
+    else
+        echo " "
+        echo "Marathon-lb failed to launch healthy."
+
+        status_line "Marathon-lb stdout:"
+        dcos task log marathon-lb stdout --lines=50
+
+        status_line "Marathon-lb stderr:"        
+        dcos task log marathon-lb stderr --lines=50
+
+        delete_cluster
+        exit 1
+    fi
+}
+
+
+run_integration_tests() {
+    status_line "Running integration tests."
+
+    cd ci/
+    pytest -s -vv test_marathon_lb.py
+}
+
+
+delete_cluster() {
+    status_line "Deleting cluster."
+    time wrapped_dcos_launch delete
+}
+
+
+# Launching cluster through dcos-launch & setting up the CLI.
+dcos_template
+download_cli
+launch_cluster
+configure_cluster
+
+# Building MLB Docker image.
+change_into_mlb_dir
+docker_build
+docker_login
+docker_push
+
+# Launching MLB and running integration tests.
+launch_marathonlb
+run_integration_tests
+
+# Deleting cluster through dcos-launch.
+delete_cluster

--- a/ci/ci-integration.sh
+++ b/ci/ci-integration.sh
@@ -137,7 +137,7 @@ EOF
     # DefaultInstanceType parameter has not been backported into 1.9 CF templates.
     # The templates actually hardcode in this parameter instead.
     if [ "${DCOS_VERSION}" != '1.9' ]; then
-        echo "    DefaultInstanceType: m4.large" >> config.yaml
+        echo "    DefaultInstanceType: m4.xlarge" >> config.yaml
     fi
 
     if [ "${VARIANT}" == 'ee' ]; then

--- a/ci/ci-integration.sh
+++ b/ci/ci-integration.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-export LC_ALL="en_US.UTF-8"
-
 # Do not fail upon error
 set +eo pipefail
+
+export LC_ALL="en_US.UTF-8"
 
 export CLUSTER_URL=${CLUSTER_URL:="uninitialized"}
 export PUBLIC_AGENT_IP=${PUBLIC_AGENT_IP:="uninitialized"}

--- a/ci/test_marathon_lb.py
+++ b/ci/test_marathon_lb.py
@@ -1,0 +1,86 @@
+import json
+import logging
+import os
+import pytest
+import re
+import requests
+import retrying
+import shakedown
+
+import dcos
+
+from dcos import marathon
+
+log = logging.getLogger(__name__)
+
+
+def get_json(file_name):
+  """ Retrieves json app definitions for Docker and UCR backends.  
+  """
+  with open(file_name) as f:
+    return json.load(f)
+
+
+def find_app_port(config, app_name):
+  """ Finds the port associated with the app in haproxy_getconfig through regex pattern matching.
+  """
+  pattern = re.search(r'{0}(.+?)\n  bind .+:\d+'.format(app_name), config)
+  return pattern.group()[-5:]
+
+
+@retrying.retry(stop_max_delay=10000)
+def get_app_port(app_name):
+  """ Returns the port that the app is configured on.
+  """
+  request_haproxy_getconfig = requests.get('http://{}:9090/_haproxy_getconfig'.format(os.environ['PUBLIC_AGENT_IP']))
+  port = find_app_port(request_haproxy_getconfig.content.decode("utf-8"), app_name)
+  return port
+
+
+@retrying.retry(stop_max_delay=10000)
+def get_app_content(app_port):
+  """ Returns the content of the app.
+  """
+  request_app_port = requests.get('http://{}:{}'.format(os.environ['PUBLIC_AGENT_IP'], app_port))
+  return (request_app_port.content.decode("utf-8").rstrip(), request_app_port.status_code)
+
+
+def test_backends():
+  """ Tests Marathon-lb against a number of Docker and UCR backends. 
+  All backends are defined in the following directories: backends/ & backends_1.9/.
+  The test retrieves the port to which the apps are configured against from _haproxy_getconfig. 
+  Each app is configured to display its app_id as content if launched healthy. 
+  The test then asserts to check whether the text response matches the expected test response.
+  """
+
+  if os.environ['DCOS_VERSION'] == '1.9':
+    app_defs = [get_json('backends_1.9/' + filename) for filename in os.listdir('backends_1.9/')]
+  else:
+    app_defs = [get_json('backends/' + filename) for filename in os.listdir('backends/')]
+
+  for app_def in app_defs:
+    app_id = app_def['id']
+    
+    app_name = app_id[1:] if app_id[0] == '/' else app_id
+    print(app_name)
+
+    client = marathon.create_client()
+    client.add_app(app_def)
+
+    shakedown.deployment_wait(app_id=app_id)
+    app = client.get_app(app_id)
+    assert app['tasksRunning'] == app_def['instances'], "The number of running tasks is {}, but {} were expected.".format(app["tasksRunning"], app_def['instances'])
+    log.info('The number of running tasks for {appname} is {number}'.format(appname=app_name, number=app['tasksRunning']))
+
+    port = get_app_port(app_name)
+    expected_port = app_def["labels"]["HAPROXY_0_PORT"]
+    port_binding_err_msg = "{} is bound to {}, when it should be bound to {}.".format(app_name, port, expected_port)
+    assert port == expected_port, port_binding_err_msg
+    log.info('{appname} is bound to port {number}.'.format(appname=app_name, number=port))
+
+    text_response, status_code = get_app_content(port)
+    expected_text_response = app_name
+    text_response_err_msg = "Text response is {}, when it should be {}.".format(text_response, expected_text_response)
+    if status_code == 200:  
+      assert text_response == expected_text_response, text_response_err_msg
+    log.info('Text response is {content}.'.format(content=text_response))

--- a/ci/test_marathon_lb.py
+++ b/ci/test_marathon_lb.py
@@ -1,86 +1,86 @@
 import json
 import logging
 import os
-import pytest
 import re
 import requests
 import retrying
 import shakedown
 
-import dcos
-
 from dcos import marathon
 
 log = logging.getLogger(__name__)
+logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
 
 
 def get_json(file_name):
-  """ Retrieves json app definitions for Docker and UCR backends.  
-  """
-  with open(file_name) as f:
-    return json.load(f)
+    """ Retrieves json app definitions for Docker and UCR backends.
+    """
+    with open(file_name) as f:
+        return json.load(f)
 
 
 def find_app_port(config, app_name):
-  """ Finds the port associated with the app in haproxy_getconfig through regex pattern matching.
-  """
-  pattern = re.search(r'{0}(.+?)\n  bind .+:\d+'.format(app_name), config)
-  return pattern.group()[-5:]
+    """ Finds the port associated with the app in haproxy_getconfig. 
+    This is done through regex pattern matching.
+    """
+    pattern = re.search(r'{0}(.+?)\n  bind .+:\d+'.format(app_name), config)
+    return pattern.group()[-5:]
 
 
 @retrying.retry(stop_max_delay=10000)
 def get_app_port(app_name):
-  """ Returns the port that the app is configured on.
-  """
-  request_haproxy_getconfig = requests.get('http://{}:9090/_haproxy_getconfig'.format(os.environ['PUBLIC_AGENT_IP']))
-  port = find_app_port(request_haproxy_getconfig.content.decode("utf-8"), app_name)
-  return port
+    """ Returns the port that the app is configured on.
+    """
+    request_haproxy_getconfig = requests.get('http://{}:9090/_haproxy_getconfig'.format(os.environ['PUBLIC_AGENT_IP']))
+    port = find_app_port(request_haproxy_getconfig.content.decode("utf-8"), app_name)
+    return port
 
 
 @retrying.retry(stop_max_delay=10000)
 def get_app_content(app_port):
-  """ Returns the content of the app.
-  """
-  request_app_port = requests.get('http://{}:{}'.format(os.environ['PUBLIC_AGENT_IP'], app_port))
-  return (request_app_port.content.decode("utf-8").rstrip(), request_app_port.status_code)
+    """ Returns the content of the app.
+    """
+    request_app_port = requests.get('http://{}:{}'.format(os.environ['PUBLIC_AGENT_IP'], app_port))
+    return (request_app_port.content.decode("utf-8").rstrip(), request_app_port.status_code)
 
 
 def test_backends():
-  """ Tests Marathon-lb against a number of Docker and UCR backends. 
-  All backends are defined in the following directories: backends/ & backends_1.9/.
-  The test retrieves the port to which the apps are configured against from _haproxy_getconfig. 
-  Each app is configured to display its app_id as content if launched healthy. 
-  The test then asserts to check whether the text response matches the expected test response.
-  """
+    """ Tests Marathon-lb against a number of Docker and UCR backends.
+    All backends are defined in the following directories: backends/ & backends_1.9/.
+    The test retrieves the port to which the apps are configured against from _haproxy_getconfig.
+    Each app is configured to display its app_id as content if launched healthy.
+    The test then asserts to check whether the text response matches the expected test response.
+    """
 
-  if os.environ['DCOS_VERSION'] == '1.9':
-    app_defs = [get_json('backends_1.9/' + filename) for filename in os.listdir('backends_1.9/')]
-  else:
-    app_defs = [get_json('backends/' + filename) for filename in os.listdir('backends/')]
+    if os.environ['DCOS_VERSION'] == '1.9':
+        app_defs = [get_json('backends_1.9/' + filename) for filename in os.listdir('backends_1.9/')]
+    else:
+        app_defs = [get_json('backends/' + filename) for filename in os.listdir('backends/')]
 
-  for app_def in app_defs:
-    app_id = app_def['id']
-    
-    app_name = app_id[1:] if app_id[0] == '/' else app_id
-    print(app_name)
+    for app_def in app_defs:
+        app_id = app_def['id']
 
-    client = marathon.create_client()
-    client.add_app(app_def)
+        app_name = app_id[1:] if app_id[0] == '/' else app_id
+        print(app_name)
+        log.info('{appname} is being tested.'.format(appname=app_name))
 
-    shakedown.deployment_wait(app_id=app_id)
-    app = client.get_app(app_id)
-    assert app['tasksRunning'] == app_def['instances'], "The number of running tasks is {}, but {} were expected.".format(app["tasksRunning"], app_def['instances'])
-    log.info('The number of running tasks for {appname} is {number}'.format(appname=app_name, number=app['tasksRunning']))
+        client = marathon.create_client()
+        client.add_app(app_def)
 
-    port = get_app_port(app_name)
-    expected_port = app_def["labels"]["HAPROXY_0_PORT"]
-    port_binding_err_msg = "{} is bound to {}, when it should be bound to {}.".format(app_name, port, expected_port)
-    assert port == expected_port, port_binding_err_msg
-    log.info('{appname} is bound to port {number}.'.format(appname=app_name, number=port))
+        shakedown.deployment_wait(app_id=app_id)
+        app = client.get_app(app_id)
+        assert app['tasksRunning'] == app_def['instances'], "The number of running tasks is {}, but {} were expected.".format(app["tasksRunning"], app_def['instances'])
+        log.info('The number of running tasks for {appname} is {number}'.format(appname=app_name, number=app['tasksRunning']))
 
-    text_response, status_code = get_app_content(port)
-    expected_text_response = app_name
-    text_response_err_msg = "Text response is {}, when it should be {}.".format(text_response, expected_text_response)
-    if status_code == 200:  
-      assert text_response == expected_text_response, text_response_err_msg
-    log.info('Text response is {content}.'.format(content=text_response))
+        port = get_app_port(app_name)
+        expected_port = app_def["labels"]["HAPROXY_0_PORT"]
+        port_binding_err_msg = "{} is bound to {}, when it should be bound to {}.".format(app_name, port, expected_port)
+        assert port == expected_port, port_binding_err_msg
+        log.info('{appname} is bound to port {number}.'.format(appname=app_name, number=port))
+
+        text_response, status_code = get_app_content(port)
+        expected_text_response = app_name
+        text_response_err_msg = "Text response is {}, when it should be {}.".format(text_response, expected_text_response)
+        if status_code == 200:
+            assert text_response == expected_text_response, text_response_err_msg
+        log.info('Text response is {content}.'.format(content=text_response))


### PR DESCRIPTION
Adding both CI and integration tests for Marathon LB. These tests are triggered whenever a PR is created. 

The CI builds and launches Marathon LB based on a docker image. The integration tests launch simple UCR & Docker backends which are then used to test against Marathon LB.