### PR TITLE
Add missing parameter to regenerate_config call

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -2102,4 +2102,5 @@ if __name__ == '__main__':
                           not args.dont_bind_http_https,
                           args.ssl_certs,
                           ConfigTemplater(),
-                          args.haproxy_map)
+                          args.haproxy_map
+                          args.group_https_by_vhost)


### PR DESCRIPTION
Fixes https://github.com/mesosphere/marathon-lb/issues/572