### PR TITLE
Replaced libcurl3 to libcurl4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL LAST_MODIFIED=20180403
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         inetutils-syslogd \
-        libcurl3 \
+        libcurl4 \
         liblua5.3-0 \
         libssl1.1 \
         openssl \


### PR DESCRIPTION
This PR should fix #593 Debian buster doesn't support libcurl3 anymore hence the issue of libcurl not found when executing the docker image from dockerhub.