### PR TITLE
Increase ZDD pids from 1 to 2

### DIFF
--- a/zdd.py
+++ b/zdd.py
@@ -133,7 +133,7 @@ def check_haproxy_reloading(haproxy_url):
         # Assume reloading on any error, this should be caught with a timeout
         return True
 
-    if len(pids) > 1:
+    if len(pids) > 2:
         logger.info("Waiting for {} pids on {}".format(len(pids), haproxy_url))
         return True
 


### PR DESCRIPTION
referencing #588
since the container now runs 2 haproxy processes the check_haproxy_reloading function needs to be aware of this