### PR TITLE
tests/dockerfile: update base image

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,12 +1,21 @@
-FROM debian:jessie
+FROM mesosphere/marathon-lb:latest
 
-COPY  . /marathon-lb
-
-RUN apt-get update && apt-get install -y ruby apache2 vim curl ruby-dev build-essential \
+RUN apt-get update && apt-get install -y curl gnupg \
     && echo "deb http://debian.datastax.com/community stable main" | tee -a /etc/apt/sources.list.d/cassandra.sources.list \
     && curl -L http://debian.datastax.com/debian/repo_key | apt-key add - \
-    && apt-get update && apt-get install -y cassandra \
+    && apt-get update \
+    && apt-get install -y \
+        ruby \
+        apache2 \
+        vim \
+        ruby-dev \
+        build-essential \
+        cassandra \
     && gem install --no-ri --no-rdoc cassandra-driver \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /marathon-lb
+
+# NOTE(jkoelker) Clear out the entrypoint and cmd from the parent image
+ENTRYPOINT []
+CMD []


### PR DESCRIPTION
Changes the base image to `mesosphere/marathon-lb:latest`. Since this
image requires a copy of `/marathon-lb`, reusing the existing image
instead of creating another one helps with caching. Also since the
latest `cassandra-driver` no longer works on `debian:jessie` and
`mesosphere/marathon-lb:latest` is already built upon `debian:buster`
using it as the base makes sense.