### PR TITLE
updated to 1.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ RUN set -x \
     && apt-get purge -y --auto-remove dirmngr gpg wget
 
 
-ENV HAPROXY_MAJOR=1.8 \
-    HAPROXY_VERSION=1.8.19 \
-    HAPROXY_MD5=713d995d8b072a4ca8561ab389b82b7a
+ENV HAPROXY_MAJOR=1.9 \
+    HAPROXY_VERSION=1.9.5 \
+    HAPROXY_MD5=3f61ebad5074d78ba7d88422624b328c
 
 COPY requirements.txt /marathon-lb/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN set -x \
 
 
 ENV HAPROXY_MAJOR=1.9 \
-    HAPROXY_VERSION=1.9.5 \
-    HAPROXY_MD5=3f61ebad5074d78ba7d88422624b328c
+    HAPROXY_VERSION=1.9.6 \
+    HAPROXY_MD5=7ca1faa1e84d7d72ff9f3a5337dc8fda
 
 COPY requirements.txt /marathon-lb/
 


### PR DESCRIPTION
updated, tests passed. 

```
marathon-lb on  master on 🐳 v18.09.3 took 9m 22s
[I] ➜ make test-integration
+ Build container image mikejennings/marathon-lb:5d6393b
+ Pushing image to hub
docker push mikejennings/marathon-lb:5d6393b
The push refers to repository [docker.io/mikejennings/marathon-lb]
f63d319a8064: Pushed
e1cd2bc04ce0: Layer already exists
5aab828cc6d0: Layer already exists
5e02ae959b09: Layer already exists
6325e828e90a: Layer already exists
9bc98e914376: Layer already exists
5d6393b: digest: sha256:19a46b06e643183786143e16ee7b51553bbcedd5788888f59e078d5baefad68b size: 1580
+ Build devkit image mesosphere/marathon-lb-devkit:latest
+ Discovering Cluster URL
+ Cluster URL: http://172.17.0.4
+ Discovering Public Node IP
+ Public Node IP: 172.17.0.6
+ Integration Testng with image mikejennings/marathon-lb:5d6393b
========================================================= test session starts =========================================================
platform linux -- Python 3.7.3rc1, pytest-3.10.1, py-1.8.0, pluggy-0.9.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /marathon-lb/ci, inifile:
plugins: timeout-1.3.3, dcos-test-utils-0.1
collected 20 items

test_marathon_lb_dcos_e2e.py::test_port[backends/docker_ippc.json] PASSED                                                       [  5%]
test_marathon_lb_dcos_e2e.py::test_response[backends/docker_ippc.json] PASSED                                                   [ 10%]
test_marathon_lb_dcos_e2e.py::test_port[backends/ucr_host.json] PASSED                                                          [ 15%]
test_marathon_lb_dcos_e2e.py::test_response[backends/ucr_host.json] PASSED                                                      [ 20%]
test_marathon_lb_dcos_e2e.py::test_port[backends/docker_bridge.json] PASSED                                                     [ 25%]
test_marathon_lb_dcos_e2e.py::test_response[backends/docker_bridge.json] PASSED                                                 [ 30%]
test_marathon_lb_dcos_e2e.py::test_port[backends/ucr_ippc.json] PASSED                                                          [ 35%]
test_marathon_lb_dcos_e2e.py::test_response[backends/ucr_ippc.json] PASSED                                                      [ 40%]
test_marathon_lb_dcos_e2e.py::test_port[backends/ucr_bridge.json] PASSED                                                        [ 45%]
test_marathon_lb_dcos_e2e.py::test_response[backends/ucr_bridge.json] PASSED                                                    [ 50%]
test_marathon_lb_dcos_e2e.py::test_port[backends/docker_host.json] PASSED                                                       [ 55%]
test_marathon_lb_dcos_e2e.py::test_response[backends/docker_host.json] PASSED                                                   [ 60%]
test_marathon_lb_dcos_e2e.py::test_port[backends_1.9/docker_ippc.json] SKIPPED                                                  [ 65%]
test_marathon_lb_dcos_e2e.py::test_response[backends_1.9/docker_ippc.json] SKIPPED                                              [ 70%]
test_marathon_lb_dcos_e2e.py::test_port[backends_1.9/ucr_host.json] SKIPPED                                                     [ 75%]
test_marathon_lb_dcos_e2e.py::test_response[backends_1.9/ucr_host.json] SKIPPED                                                 [ 80%]
test_marathon_lb_dcos_e2e.py::test_port[backends_1.9/docker_bridge.json] SKIPPED                                                [ 85%]
test_marathon_lb_dcos_e2e.py::test_response[backends_1.9/docker_bridge.json] SKIPPED                                            [ 90%]
test_marathon_lb_dcos_e2e.py::test_port[backends_1.9/docker_host.json] SKIPPED                                                  [ 95%]
test_marathon_lb_dcos_e2e.py::test_response[backends_1.9/docker_host.json] SKIPPED                                              [100%]

=============================================== 12 passed, 8 skipped in 175.52 seconds ==============================================
```