### PR TITLE
utils: send auth to any host redirected to

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -162,6 +162,7 @@ class CurlHttpEventStream(object):
         # when they're coming from a non-leader. So we follow redirects.
         self.curl.setopt(pycurl.FOLLOWLOCATION, True)
         self.curl.setopt(pycurl.MAXREDIRS, 1)
+        self.curl.setopt(pycurl.UNRESTRICTED_AUTH, True)
 
         # The below settings are to prevent the connection from hanging if the
         # connection breaks silently. Since marathon-lb only listens, silent


### PR DESCRIPTION
Curl will not send the auth credentials to a host that it has been
redirected to by default. Set `pycurl.UNRESTRICTED_AUTH` which is the
option for `--location-trusted` to allow sending the name + password to
all hosts that the site may redirect to.

Fixes: #632