### PR TITLE
checks if healthChecks is a key of app before checking length (#637)

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1636,7 +1636,7 @@ def get_apps(marathon, apps=[]):
             old_tasks = sorted(old['tasks'], key=lambda task: task['id'])
 
             healthy_new_instances = 0
-            if len(app['healthChecks']) > 0:
+            if 'healthChecks' in app and len(app['healthChecks']) > 0:
                 for task in new['tasks']:
                     if 'healthCheckResults' not in task:
                         continue


### PR DESCRIPTION
When grouping services with HAPROXY_DEPLOYMENT_GROUP without a health check marathon-lb crashes.


https://github.com/mesosphere/marathon-lb/issues/637