### PR TITLE
Use self.host property once in get_event_stream

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -244,7 +244,7 @@ class Marathon(object):
 
     def get_event_stream(self, events):
         self.current_host = self.host
-        url = self.host + "/v2/events"
+        url = self.current_host + "/v2/events"
         if events:
             url += "?" + urllib.parse.urlencode({'event_type': events},
                                                 doseq=True)


### PR DESCRIPTION
`self.host` cycles through available Marathon URLs, and it was accessed twice in `get_event_stream`, which made it access the same Marathon instance, if two URLs were supplied, which is especially profound if the instance being accessed over and over again is down.