### PR TITLE
Fix #647 - Remove urllib3 conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pycurl
 python-dateutil
 requests
 six
-urllib3


### PR DESCRIPTION
This should help remove potential conflicts between `urllib3` and `requests`. `requests` anyways transitively depends on `urllib3`, so removing this shouldn't be a problem.