### PR TITLE
docker: bump haproxy to 2.0.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN set -x \
 
 
 ENV HAPROXY_MAJOR=2.0 \
-    HAPROXY_VERSION=2.0.7 \
-    HAPROXY_MD5=1db3d8bedb3482ffd3a930e24e414b55
+    HAPROXY_VERSION=2.0.8 \
+    HAPROXY_MD5=745fe3f6625bb0f49380c2b6c6b350a7
 
 COPY requirements.txt /marathon-lb/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN set -x \
 
 
 ENV HAPROXY_MAJOR=2.0 \
-    HAPROXY_VERSION=2.0.9 \
-    HAPROXY_MD5=dd1112a210392fa9232019a6e69e1d3c
+    HAPROXY_VERSION=2.0.10 \
+    HAPROXY_MD5=501f490f0fb6c01099686d2f0e02f644
 
 COPY requirements.txt /marathon-lb/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN set -x \
 
 
 ENV HAPROXY_MAJOR=2.0 \
-    HAPROXY_VERSION=2.0.8 \
-    HAPROXY_MD5=745fe3f6625bb0f49380c2b6c6b350a7
+    HAPROXY_VERSION=2.0.9 \
+    HAPROXY_MD5=dd1112a210392fa9232019a6e69e1d3c
 
 COPY requirements.txt /marathon-lb/
 


### PR DESCRIPTION
HAProxy 2.0.10 has been released with a few major fixes: https://www.mail-archive.com/haproxy@formilux.org/msg35488.html