### PR TITLE
Fix bug in checking healthChecks at first (#655)

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1691,10 +1691,10 @@ def get_apps(marathon, apps=[]):
                 for task in new['tasks']:
                     if 'healthCheckResults' not in task:
                         continue
-                    alive = True
+                    alive = False
                     for result in task['healthCheckResults']:
-                        if not result['alive']:
-                            alive = False
+                        if result['alive']:
+                            alive = True
                     if alive:
                         healthy_new_instances += 1
             else:
@@ -1802,15 +1802,15 @@ def get_apps(marathon, apps=[]):
 
             if marathon.health_check() and 'healthChecks' in app and \
                len(app['healthChecks']) > 0:
-                alive = True
+                alive = False
                 if 'healthCheckResults' not in task:
                     # use previously cached result, if it exists
                     if not healthCheckResultCache.get(task['id'], False):
                         continue
                 else:
                     for result in task['healthCheckResults']:
-                        if not result['alive']:
-                            alive = False
+                        if result['alive']:
+                            alive = True
                     healthCheckResultCache.set(task['id'], alive)
                     if not alive:
                         continue


### PR DESCRIPTION
Suppose you have an app that needs to warming up at first.
( e.g. http response code: 503 -> 200 )

When start a app that has healthChecks
task have healthChecks Results property but don't have any element in array at first

But it add backend server in haproxy

Eventually, 
Before healthChecks run once at first
request's packet will flow in a app that don't check healthChecks

#655
