### PR TITLE
Specify marathon-lb user agent

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -185,7 +185,8 @@ class Marathon(object):
                     auth=auth,
                     headers={
                         'Accept': 'application/json',
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'User-Agent': 'marathon-lb'
                     },
                     timeout=(3.05, 46),
                     **kwargs

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ cryptography
 PyJWT==1.4.0
 pycurl
 python-dateutil
-requests
+requests>=2.22.0
 six


### PR DESCRIPTION
It's helpful for debugging cluster issues to have different user agents for each component.