### PR TITLE
Resolve Critical CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stable-20200224-slim
 
 LABEL LAST_MODIFIED=20191004
 


### PR DESCRIPTION
Updating the Debian image to reference a stable `slim` version resolves the following critical Common Vulnerabilities and Exposures and does not impact functionality:

- CVE-2019-5481 (https://security-tracker.debian.org/tracker/CVE-2019-5481)
- CVE-2019-5482 ( https://security-tracker.debian.org/tracker/CVE-2019-5482)