### PR TITLE
Use difflib to log haproxy config changes

### DIFF
--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -34,6 +34,7 @@ import threading
 import time
 import datetime
 import urllib.parse
+import difflib
 from itertools import cycle
 from collections import defaultdict
 from operator import attrgetter
@@ -1507,6 +1508,11 @@ def compareWriteAndReloadConfig(config, config_file, domain_map_array,
             logger.info(
                 "running config is different from generated config"
                 " - reloading")
+            for hunk in difflib.unified_diff(
+                runningConfig.splitlines(),
+                config.splitlines()
+            ):
+                logger.info(hunk)
             if writeConfigAndValidate(
                     config, config_file, domain_map_string, domain_map_file,
                     app_map_string, app_map_file, haproxy_map):


### PR DESCRIPTION
Will generate nice log like this:

```
marathon_lb: running config is different from generated config - reloading
marathon_lb: ---
marathon_lb: +++
marathon_lb: @@ -1041,11 +1041,6 @@
marathon_lb:    mode tcp
marathon_lb:    use_backend platform_proj_37226
marathon_lb:
marathon_lb: -frontend platform_proj_37360
marathon_lb: -  bind *:37360
marathon_lb: -  mode tcp
marathon_lb: -  use_backend platform_proj_37360
marathon_lb: -
marathon_lb:  frontend platform_proj_38903
marathon_lb:    bind *:38903
marathon_lb:    mode tcp
marathon_lb: @@ -3106,11 +3101,6 @@
marathon_lb:    mode tcp
marathon_lb:    server server.com.10_1_1_1_31077 10.1.1.1:31077 id 4244
marathon_lb:
marathon_lb: -backend platform_proj_37360
marathon_lb: -  balance roundrobin
marathon_lb: -  mode tcp
marathon_lb: -  server server2.com_192_168_1_1_31784 192.168.1.1:31784 id 17977
marathon_lb: -
marathon_lb:  backend platform_proj_38903
marathon_lb:    balance roundrobin
marathon_lb:    mode tcp
```

Which is very helpful for auditing and debugging !